### PR TITLE
Recreate the parser with scopes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1,349 +1,958 @@
 module.exports = grammar({
   name: "llvm",
 
+  conflicts: $ => [
+    [$.type_and_value],
+    [$.instruction_alloca], [$.instruction_getelementptr], [$._load_store_suffix], [$.instruction_extractvalue],
+    [$.instruction_insertvalue], [$.instruction_phi], [$.instruction_cmpxchg], [$.instruction_atomicrmw], [$.instruction_br],
+  ],
+
+  extras: $ => [
+    /\s+/,
+    $.comment,
+  ],
+
   rules: {
-    module: ($) =>
-      repeat(
-        choice(
-          $.type,
-          $.statement,
-          $.number,
-          $.comment,
-          $.string,
-          $.label,
-          $.keyword,
-          $.boolean,
-          $.float,
-          $.constant,
-          $.identifier,
-          $.symbol,
-          $.bracket
-        )
-      ),
-
-    type: ($) =>
+    module: $ => repeat(
       choice(
-        "void",
-        "half",
-        "bfloat",
-        "float",
-        "double",
-        "x86_fp80",
-        "fp128",
-        "pcc_fp128",
-        "label",
-        "metadata",
-        "x86_mmx",
-        "x86_amx",
-        /i\d+/
-      ),
+        // Parse functions from LLParser::parseTargetDefinitions
+        $.target_definition,
+        $.source_file_name,
 
-    statement: ($) =>
+        // Parse functions from LLParser::parseTopLevelEntities
+        $.declare,
+        $.define,
+        $.module_asm,
+        $.global_type,
+        $.global_global,
+        $.alias,
+        $.ifunc,
+        $.comdat,
+        $.global_metadata,
+        $.summary_entry,
+        $.unnamed_attr_grp,
+        $.use_list_order,
+        $.use_list_order_bb,
+      ),
+    ),
+
+    comment: $ => /;.*/,
+
+    attr_ref: $ => /#[0-9]+/,
+    comdat_ref: $ => token(seq('$', token.immediate(choice(
+      /[-a-zA-Z$._][-a-zA-Z$._0-9]*/,
+
+      /\d+/,
+      /"[^"]*"/,
+    )))),
+    global_var: $ => token(seq('@', token.immediate(choice(
+      /[-a-zA-Z$._][-a-zA-Z$._0-9]*/,
+      /\d+/,
+      /"[^"]*"/,
+    )))),
+    local_var: $ => token(seq('%', token.immediate(choice(
+      /[-a-zA-Z$._][-a-zA-Z$._0-9]*/,
+      /\d+/,
+      /"[^"]*"/,
+    )))),
+    label: $ => token(seq(choice(
+      /[-a-zA-Z$._][-a-zA-Z$._0-9]*/,
+      /\d+/,
+      /"[^"]*"/,
+    ), token.immediate(':'))),
+
+    metadata_ref: $ => token(seq('!', token.immediate(choice(
+      /[-a-zA-Z$._\\][-a-zA-Z$._0-9\\]*/,
+      /\d+/,
+      /"[^"]*"/,
+    )))),
+    metadata_name: $ => token(seq('!', token.immediate(choice(
+      /[-a-zA-Z$._\\][-a-zA-Z$._0-9\\]*/,
+      /\d+/,
+      /"[^"]*"/,
+    )))),
+    summary_ref: $ => token(seq('^', token.immediate(choice(
+      /[-a-zA-Z$._][-a-zA-Z$._0-9]*/,
+      /\d+/,
+      /"[^"]*"/,
+    )))),
+
+    string: $ => /"[^"]*"/,
+    number: $ => choice(/[+-]?\d+/, /[su]?0x[KMLHR]?[0-9a-fA-F]+/), // matches int and float hex literals
+    float: $ => /[+-]?\d+\.\d*([Ee][+-]?\d+)?/,
+
+    cstring: $ => /c"[^"]*"/,
+
+    var: $ => choice($.local_var, $.global_var),
+
+    target_definition: $ => seq(
+      'target',
       choice(
-        "add",
-        "addrspacecast",
-        "alloca",
-        "and",
-        "arcp",
-        "ashr",
-        "atomicrmw",
-        "bitcast",
-        "br",
-        "catchpad",
-        "catchswitch",
-        "catchret",
-        "call",
-        "callbr",
-        "cleanuppad",
-        "cleanupret",
-        "cmpxchg",
-        "eq",
-        "exact",
-        "extractelement",
-        "extractvalue",
-        "fadd",
-        "fast",
-        "fcmp",
-        "fdiv",
-        "fence",
-        "fmul",
-        "fneg",
-        "fpext",
-        "fptosi",
-        "fptoui",
-        "fptrunc",
-        "free",
-        "freeze",
-        "frem",
-        "fsub",
-        "getelementptr",
-        "icmp",
-        "inbounds",
-        "indirectbr",
-        "insertelement",
-        "insertvalue",
-        "inttoptr",
-        "invoke",
-        "landingpad",
-        "load",
-        "lshr",
-        "malloc",
-        "max",
-        "min",
-        "mul",
-        "nand",
-        "ne",
-        "ninf",
-        "nnan",
-        "nsw",
-        "nsz",
-        "nuw",
-        "oeq",
-        "oge",
-        "ogt",
-        "ole",
-        "olt",
-        "one",
-        "or",
-        "ord",
-        "phi",
-        "ptrtoint",
-        "resume",
-        "ret",
-        "sdiv",
-        "select",
-        "sext",
-        "sge",
-        "sgt",
-        "shl",
-        "shufflevector",
-        "sitofp",
-        "sle",
-        "slt",
-        "srem",
-        "store",
-        "sub",
-        "switch",
-        "trunc",
-        "udiv",
-        "ueq",
-        "uge",
-        "ugt",
-        "uitofp",
-        "ule",
-        "ult",
-        "umax",
-        "umin",
-        "une",
-        "uno",
-        "unreachable",
-        "unwind",
-        "urem",
-        "va_arg",
-        "xchg",
-        "xor",
-        "zext"
+        $.target_triple,
+        $.data_layout,
       ),
+    ),
 
-    keyword: ($) =>
+    target_triple: $ => seq(
+      'triple',
+      '=',
+      $.string,
+    ),
+
+    data_layout: $ => seq(
+      'datalayout',
+      '=',
+      $.string,
+    ),
+
+    source_file_name: $ => seq(
+      'source_filename',
+      '=',
+      $.string,
+    ),
+
+    declare: $ => seq(
+      'declare',
+      repeat($.metadata_attachment),
+      $.function_header,
+    ),
+
+    define: $ => seq(
+      'define',
+      $.function_header,
+      repeat($.metadata_attachment),
+      field('body', $.function_body),
+    ),
+
+    metadata_attachment: $ => seq(
+      $.metadata_name,
+      $.metadata,
+    ),
+
+    function_header: $ => seq(
+      repeat($.linkage),
+      optional($.calling_conv),
+      repeat($.param_or_return_attrs),
+      optional($.unnamed_addr),
+      $.type,
+      field('name', $.global_var),
+      field('arguments', $.argument_list),
+      optional($.unnamed_addr),
+      optional($.addrspace),
+      repeat($.attribute),
+    ),
+
+    linkage: $ => choice(
+      $.linkage_aux,
+      $.dso_local,
+      $.visibility,
+      $.dll_storage_class,
+      'no_cfi',
+    ),
+
+    linkage_aux: $ => choice(
+      'private',
+      'internal',
+      'weak',
+      'weak_odr',
+      'linkonce',
+      'linkonce_odr',
+      'available_externally',
+      'appending',
+      'common',
+      'extern_weak',
+      'external',
+    ),
+
+    dso_local: $ => choice(
+      'dso_local',
+      'dso_local_equivalent',
+      'dso_preemptable',
+    ),
+
+    visibility: $ => choice(
+      'default',
+      'hidden',
+      'protected',
+    ),
+
+    dll_storage_class: $ => choice(
+      'dllimport',
+      'dllexport',
+    ),
+
+    calling_conv: $ => choice(
+      'ccc',
+      'fastcc',
+      'coldcc',
+      'webkit_jscc',
+      'anyregcc',
+      'preserve_mostcc',
+      'preserve_allcc',
+      'cxx_fast_tlscc',
+      'tailcc',
+      'swiftcc',
+      'swifttailcc',
+      'cfguard_checkcc',
+      /x86_[a-z_0-9]+/,
+      /arm_[a-z_0-9]+/,
+      /aarch64_[a-z_0-9]+/,
+      /msp430_[a-z_0-9]+/,
+      /avr_[a-z_0-9]+/,
+      /ptx_[a-z_0-9]+/,
+      /spir_[a-z_0-9]+/,
+      /intel_[a-z_0-9]+/,
+      /win[a-z_0-9]+/,
+      /webkit_[a-z_0-9]+/,
+      'ghccc',
+      /swift[a-z_0-9]+/,
+      /hhvm[a-z_0-9]+/,
+      /cxx_[a-z_0-9]+/,
+      /amdgpu_[a-z_0-9]+/,
+      seq('cc', $.number),
+      $.string,
+    ),
+
+    unnamed_addr: $ => choice(
+      'unnamed_addr',
+      'local_unnamed_addr',
+    ),
+
+    type: $ => seq(
       choice(
-        "acq_rel",
-        "acquire",
-        "addrspace",
-        "alias",
-        "align",
-        "alignstack",
-        "allocsize",
-        "alwaysinline",
-        "appending",
-        "argmemonly",
-        "arm_aapcs_vfpcc",
-        "arm_aapcscc",
-        "arm_apcscc",
-        "asm",
-        "atomic",
-        "available_externally",
-        "blockaddress",
-        "builtin",
-        "byref",
-        "byval",
-        "c",
-        "caller",
-        "catch",
-        "cc",
-        "ccc",
-        "cleanup",
-        "cold",
-        "coldcc",
-        "comdat",
-        "common",
-        "constant",
-        "convergent",
-        "datalayout",
-        "declare",
-        "default",
-        "define",
-        "deplibs",
-        "dereferenceable",
-        "dereferenceable_or_null",
-        "distinct",
-        "dllexport",
-        "dllimport",
-        "dso_local",
-        "dso_preemptable",
-        "except",
-        "extern_weak",
-        "external",
-        "externally_initialized",
-        "fastcc",
-        "filter",
-        "from",
-        "gc",
-        "global",
-        "hhvm_ccc",
-        "hhvmcc",
-        "hidden",
-        "hot",
-        "immarg",
-        "inaccessiblemem_or_argmemonly",
-        "inaccessiblememonly",
-        "inalloca",
-        "initialexec",
-        "inlinehint",
-        "inreg",
-        "intel_ocl_bicc",
-        "inteldialect",
-        "internal",
-        "jumptable",
-        "linkonce",
-        "linkonce_odr",
-        "local_unnamed_addr",
-        "localdynamic",
-        "localexec",
-        "minsize",
-        "module",
-        "monotonic",
-        "msp430_intrcc",
-        "mustprogress",
-        "musttail",
-        "naked",
-        "nest",
-        "noalias",
-        "nobuiltin",
-        "nocallback",
-        "nocapture",
-        "nocf_check",
-        "noduplicate",
-        "nofree",
-        "noimplicitfloat",
-        "noinline",
-        "nomerge",
-        "nonlazybind",
-        "nonnull",
-        "noprofile",
-        "norecurse",
-        "noredzone",
-        "noreturn",
-        "nosync",
-        "noundef",
-        "nounwind",
-        "nosanitize_coverage",
-        "null_pointer_is_valid",
-        "optforfuzzing",
-        "optnone",
-        "optsize",
-        "personality",
-        "preallocated",
-        "private",
-        "protected",
-        "ptx_device",
-        "ptx_kernel",
-        "readnone",
-        "readonly",
-        "release",
-        "returned",
-        "returns_twice",
-        "safestack",
-        "sanitize_address",
-        "sanitize_hwaddress",
-        "sanitize_memory",
-        "sanitize_memtag",
-        "sanitize_thread",
-        "section",
-        "seq_cst",
-        "shadowcallstack",
-        "sideeffect",
-        "signext",
-        "source_filename",
-        "speculatable",
-        "speculative_load_hardening",
-        "spir_func",
-        "spir_kernel",
-        "sret",
-        "ssp",
-        "sspreq",
-        "sspstrong",
-        "strictfp",
-        "swiftcc",
-        "swifterror",
-        "swifttailcc",
-        "swiftself",
-        "syncscope",
-        "tail",
-        "tailcc",
-        "target",
-        "thread_local",
-        "to",
-        "triple",
-        "unnamed_addr",
-        "unordered",
-        "uselistorder",
-        "uselistorder_bb",
-        "uwtable",
-        "volatile",
-        "weak",
-        "weak_odr",
-        "willreturn",
-        "win64cc",
-        "within",
-        "writeonly",
-        "x86_64_sysvcc",
-        "x86_fastcallcc",
-        "x86_stdcallcc",
-        "x86_thiscallcc",
-        "zeroext"
+        $.type_keyword,
+        $.struct_type,
+        $.packed_struct_type,
+        $.array_type,
+        $.vector_type,
+        $.local_var,
       ),
+      repeat(seq(
+        repeat(seq(
+          optional($.addrspace),
+          '*',
+        )),
+        $.argument_list, // function
+      )),
+      repeat(seq(
+        optional($.addrspace),
+        '*',
+      )),
+      optional($.addrspace), // opaque pointer
+    ),
 
-    number: ($) => /-?\d+/,
+    type_keyword: $ => choice(
+      'void',
+      'half',
+      'bfloat',
+      'float',
+      'double',
+      'x86_fp80',
+      'fp128',
+      'ppc_fp128',
+      'label',
+      'metadata',
+      'x86_mmx',
+      'x86_amx',
+      'token',
+      'opaque',
+      'ptr',
+      /i\d+/,
+    ),
 
-    float: ($) => choice(/-?\d+\.\d*(e[+-]\d+)\?/, /0x[0-9a-fA-F]+/),
+    struct_type: $ => seq('{', optional($.struct_body), '}'),
+    packed_struct_type: $ => seq('<{', optional($.struct_body), '}>'),
+    array_type: $ => seq('[', $.array_vector_body, ']'),
+    vector_type: $ => seq('<', $.array_vector_body, '>'),
 
-    boolean: ($) => choice("true", "false"),
+    struct_body: $ => commaSep1($.type),
 
-    constant: ($) =>
-      choice("zeroinitializer", "undef", "null", "none", "poison", "vscale"),
+    array_vector_body: $ => seq(
+      optional(seq('vscale', 'x')),
+      $.number,
+      'x',
+      $.type,
+    ),
 
-    comment: ($) => /;.*/,
+    addrspace: $ => seq(
+      'addrspace',
+      '(',
+      $.number,
+      ')',
+    ),
 
-    string: ($) => /[!c]?"(\\\\|\\"|.)*"/,
+    argument_list: $ => seq(
+      '(',
+      commaSep($.argument),
+      ')',
+    ),
 
-    label: ($) => /[-a-zA-Z$._][-a-zA-Z$._0-9]*:/,
+    argument: $ => choice(
+      prec(1, seq(
+        'metadata',
+        repeat($.param_or_return_attrs),
+        optional($.metadata),
+      )),
+      seq(
+        $.type,
+        repeat($.param_or_return_attrs),
+        optional($.value),
+      ),
+      '...',
+    ),
 
-    identifier: ($) =>
+    param_or_return_attrs: $ => choice(
+      prec(1, seq('align', $.number)),
+      seq(
+        $.attribute_name,
+        optional(seq('(', choice($.type, $.number), ')')),
+      ),
+    ),
+
+    attribute: $ => choice(
+      seq(
+        choice($.attribute_name, $.string, $.attr_ref),
+        optional(choice(
+          seq('(', commaSep(choice($.type, $.number)), ')'),
+          seq('=', choice($.string, $.number)),
+        )),
+      ),
+      seq('section', $.string),
+      seq('partition', $.string),
+      seq('comdat', optional(seq('(', $.comdat_ref, ')'))),
+      $.alignment,
+      seq('gc', $.string),
+      seq('prefix', $.type_and_value),
+      seq('prologue', $.type_and_value),
+      seq('personality', $.type_and_value),
+    ),
+
+    // Extracted from the LLVM Language Reference
+    attribute_name: $ => choice(
+      'alignstack',
+      'allocsize',
+      'alwaysinline',
+      'builtin',
+      'cold',
+      'convergent',
+      'disable_sanitizer_instrumentation',
+      'hot',
+      'inaccessiblememonly',
+      'inaccessiblemem_or_argmemonly',
+      'inlinehint',
+      'jumptable',
+      'minsize',
+      'naked',
+      'no-jump-tables',
+      'nobuiltin',
+      'noduplicate',
+      'nofree',
+      'noimplicitfloat',
+      'noinline',
+      'nomerge',
+      'nonlazybind',
+      'noprofile',
+      'noredzone',
+      'indirect-tls-seg-refs',
+      'noreturn',
+      'norecurse',
+      'willreturn',
+      'nosync',
+      'nounwind',
+      'nosanitize_coverage',
+      'null_pointer_is_valid',
+      'optforfuzzing',
+      'optnone',
+      'optsize',
+      'readnone',
+      'readonly',
+      'writeonly',
+      'argmemonly',
+      'returns_twice',
+      'safestack',
+      'sanitize_address',
+      'sanitize_memory',
+      'sanitize_thread',
+      'sanitize_hwaddress',
+      'sanitize_memtag',
+      'speculative_load_hardening',
+      'speculatable',
+      'ssp',
+      'sspstrong',
+      'sspreq',
+      'strictfp',
+      'uwtable',
+      'nocf_check',
+      'shadowcallstack',
+      'mustprogress',
+      'vscale_range',
+      'preallocated',
+      'zeroext',
+      'signext',
+      'inreg',
+      'byval',
+      'byref',
+      'inalloca',
+      'sret',
+      'elementtype',
+      'align',
+      'noalias',
+      'nocapture',
+      'nest',
+      'returned',
+      'nonnull',
+      'dereferenceable',
+      'dereferenceable_or_null',
+      'swiftself',
+      'swiftasync',
+      'swifterror',
+      'immarg',
+      'noundef',
+    ),
+
+    function_body: $ => seq(
+      '{',
+      repeat(choice($.label, $.instruction)),
+      repeat($.use_list_order),
+      '}',
+    ),
+
+    instruction: $ => seq(
+      optional(seq($.local_var, '=')),
+      $._instruction_body,
+      repeat($.metadata_refs),
+    ),
+
+    // Cases from LLParser::parseInstruction
+    _instruction_body: $ => choice(
+      $.instruction_unreachable,
+      $.instruction_ret,
+      $.instruction_br,
+      $.instruction_resume,
+      $.instruction_freeze,
+      $.instruction_indirectbr,
+      $.instruction_extractelement,
+      $.instruction_insertelement,
+      $.instruction_select,
+      $.instruction_shufflevector,
+      $.instruction_fneg,
+      $.instruction_bin_op,
+      $.instruction_switch,
+      $.instruction_invoke,
+      $.instruction_cleanupret,
+      $.instruction_catchret,
+      $.instruction_catchswitch,
+      $.instruction_catchpad,
+      $.instruction_cleanuppad,
+      $.instruction_callbr,
+      $.instruction_icmp,
+      $.instruction_fcmp,
+      $.instruction_cast,
+      $.instruction_va_arg,
+      $.instruction_phi,
+      $.instruction_landingpad,
+      $.instruction_call,
+      $.instruction_alloca,
+      $.instruction_load,
+      $.instruction_store,
+      $.instruction_cmpxchg,
+      $.instruction_atomicrmw,
+      $.instruction_fence,
+      $.instruction_getelementptr,
+      $.instruction_extractvalue,
+      $.instruction_insertvalue,
+    ),
+
+    instruction_unreachable: $ => field('inst_name', 'unreachable'),
+
+    instruction_ret: $ => seq(field('inst_name', 'ret'), $.type_and_value),
+    instruction_br: $ => seq(field('inst_name', 'br'), $.type_and_value,
+      optional(seq(',', $.type_and_value, ',', $.type_and_value))),
+    instruction_resume: $ => seq(field('inst_name', 'resume'), $.type_and_value),
+    instruction_freeze: $ => seq(field('inst_name', 'freeze'), $.type_and_value),
+
+    instruction_indirectbr: $ => seq(field('inst_name', 'indirectbr'), $.type_and_value, ',', $._value_array),
+
+    instruction_extractelement: $ => seq(field('inst_name', 'extractelement'), $.type_and_value, ',', $.type_and_value),
+
+    instruction_insertelement: $ => seq(field('inst_name', 'insertelement'),
+      $.type_and_value, ',', $.type_and_value, ',', $.type_and_value),
+    instruction_select: $ => seq(field('inst_name', 'select'), repeat($.fast_math),
+      $.type_and_value, ',', $.type_and_value, ',', $.type_and_value),
+    instruction_shufflevector: $ => seq(field('inst_name', 'shufflevector'),
+      $.type_and_value, ',', $.type_and_value, ',', $.type_and_value),
+
+    instruction_fneg: $ => seq(field('inst_name', 'fneg'), repeat($.fast_math), $.type_and_value),
+
+    instruction_bin_op: $ => seq(field('inst_name', $.bin_op_keyword),
+      repeat(choice('nsw', 'nuw', 'exact', $.fast_math)), $.type_and_value, ',', $.value),
+
+    instruction_switch: $ => seq(field('inst_name', 'switch'), $.type_and_value, ',', $.type_and_value,
+      '[', repeat(seq($.type_and_value, ',', $.type_and_value)), ']'),
+
+    instruction_invoke: $ => seq(field('inst_name', 'invoke'), $._call_part, 'to',
+      $.type_and_value, 'unwind', $.type_and_value),
+
+    instruction_cleanupret: $ => seq(field('inst_name', 'cleanupret'), 'from', $.local_var, $._unwind_label),
+    instruction_catchret: $ => seq(field('inst_name', 'catchret'), 'from', $.local_var, 'to', $.type_and_value),
+
+    instruction_catchswitch: $ => seq(field('inst_name', 'catchswitch'), $._within, $._value_array, $._unwind_label),
+
+    instruction_catchpad: $ => seq(field('inst_name', 'catchpad'), $._within, $._value_array),
+    instruction_cleanuppad: $ => seq(field('inst_name', 'cleanuppad'), $._within, $._value_array),
+
+    instruction_callbr: $ => seq(field('inst_name', 'callbr'), $._call_part, 'to',
+      $.type_and_value, optional(seq('[', commaSep1($.type_and_value), ']'))),
+
+    instruction_icmp: $ => seq(field('inst_name', 'icmp'), $.icmp_cond, $.type_and_value, ',', $.value),
+
+    instruction_fcmp: $ => seq(field('inst_name', 'fcmp'), repeat($.fast_math), $.fcmp_cond, $.type_and_value, ',', $.value),
+
+    instruction_cast: $ => seq(field('inst_name', $.cast_inst), $.type_and_value, 'to', $.type),
+
+    instruction_va_arg: $ => seq(field('inst_name', 'va_arg'), $.type_and_value, ',', $.type),
+
+    instruction_phi: $ => seq(field('inst_name', 'phi'), repeat($.fast_math),
+      $.type, commaSep1(seq('[', $.value, ',', $.local_var, ']'))),
+
+    instruction_landingpad: $ => seq(field('inst_name', 'landingpad'),
+      $.type, choice($.landingpad_clause, 'cleanup'), repeat($.landingpad_clause)),
+
+    instruction_call: $ => seq(optional(choice('tail', 'musttail', 'notail')), field('inst_name', 'call'),
+      repeat($.fast_math), $._call_part),
+
+    instruction_alloca: $ => seq(field('inst_name', 'alloca'), optional('inalloca'), optional('swifterror'),
+      $.type, repeat(seq(',', choice($.type_and_value, $.alignment, $.addrspace)))),
+
+    instruction_load: $ => seq(field('inst_name', 'load'), optional('atomic'), optional('volatile'),
+      $.type, ',', $._load_store_suffix),
+
+    instruction_store: $ => seq(field('inst_name', 'store'), optional('atomic'), optional('volatile'),
+      $.type_and_value, ',', $._load_store_suffix),
+
+    instruction_cmpxchg: $ => seq(field('inst_name', 'cmpxchg'), optional('weak'), optional('volatile'),
+      $.type_and_value, ',', $.type_and_value, ',', $.type_and_value, optional($.syncscope),
+      $.atomic_ordering, $.atomic_ordering, optional(seq(',', $.alignment))),
+
+    instruction_atomicrmw: $ => seq(field('inst_name', 'atomicrmw'), optional('volatile'), $.atomic_bin_op_keyword,
+      $.type_and_value, ',', $.type_and_value, optional($.syncscope), $.atomic_ordering, optional(seq(',', $.alignment))),
+
+    instruction_fence: $ => seq(field('inst_name', 'fence'), optional($.syncscope), $.atomic_ordering),
+
+    instruction_getelementptr: $ => seq(field('inst_name', 'getelementptr'), optional('inbounds'),
+      commaSep1(seq(optional('inrange'), $.type_and_value))),
+
+    instruction_extractvalue: $ => seq(field('inst_name', 'extractvalue'), $.type_and_value, ',', commaSep1($.number)),
+
+    instruction_insertvalue: $ => seq(field('inst_name', 'insertvalue'), $.type_and_value, ',',
+      $.type_and_value, ',', commaSep1($.number)),
+
+
+    _call_part: $ => seq(
+      optional($.calling_conv),
+      repeat($.param_or_return_attrs),
+      optional($.addrspace),
+      $.type,
+      field('callee', choice($.value, $.inline_asm)),
+      field('arguments', $.argument_list),
+      repeat($.attribute),
+      optional($.operand_bundles),
+    ),
+
+    type_and_value: $ => choice(
+      prec(1, seq('metadata', $.metadata)),
+      seq(
+        $.type,
+        // Value is optional for void
+        optional($.value),
+      ),
+    ),
+
+    value: $ => choice(
+      seq(repeat($.linkage), $.var),
+      $._primitive_value,
+      $.struct_value,
+      $.packed_struct_value,
+      $.array_value,
+      $.vector_value,
+      $.blockaddress,
+      $.constant_expr,
+    ),
+
+    // single literals
+    _primitive_value: $ => choice(
+      'true',
+      'false',
+      'null',
+      'none',
+      'undef',
+      'poison',
+      'zeroinitializer',
+      $.number,
+      $.float,
+      $.string,
+      $.cstring,
+    ),
+
+    struct_value: $ => seq('{', commaSep($.type_and_value), '}'),
+    packed_struct_value: $ => seq('<{', commaSep($.type_and_value), '}>'),
+    array_value: $ => seq('[', commaSep($.type_and_value), ']'),
+    vector_value: $ => seq('<', commaSep($.type_and_value), '>'),
+
+    metadata_refs: $ => seq(
+      ',',
+      $.metadata_name,
+      $.metadata,
+    ),
+
+    operand_bundles: $ => seq(
+      '[',
+      commaSep1(seq(
+        $.string,
+        '(',
+        commaSep($.type_and_value),
+        ')',
+      )),
+      ']',
+    ),
+
+    landingpad_clause: $ => seq(
+      choice('catch', 'filter'),
+      $.type_and_value,
+    ),
+
+    blockaddress: $ => seq(
+      'blockaddress',
+      '(',
+      $.global_var,
+      ',',
+      $.local_var,
+      ')',
+    ),
+
+    constant_expr: $ => choice(
+      $.constant_cast,
+      $.constant_getelementptr,
+      $.constant_select,
+      $.constant_icmp,
+      $.constant_fcmp,
+      $.constant_extractelement,
+      $.constant_insertelement,
+      $.constant_shufflevector,
+      $.constant_extractvalue,
+      $.constant_insertvalue,
+      $.constant_fneg,
+      $.constant_bin_op,
+    ),
+
+    constant_cast: $ => seq(
+      field('inst_name', $.cast_inst),
+      '(',
+      $.type_and_value,
+      'to',
+      $.type,
+      ')',
+    ),
+
+    constant_getelementptr: $ => seq(
+      field('inst_name', 'getelementptr'),
+      optional('inbounds'),
+      '(',
+      commaSep1(seq(optional('inrange'), $.type_and_value)),
+      ')',
+    ),
+
+    constant_select: $ => seq(field('inst_name', 'select'), '(',
+      $.type_and_value, ',', $.type_and_value, ',', $.type_and_value, ')'),
+
+    constant_icmp: $ => seq(field('inst_name', 'icmp'), $.icmp_cond, '(',
+      $.type_and_value, ',', $.type_and_value, ')'),
+
+    constant_fcmp: $ => seq(field('inst_name', 'fcmp'), repeat($.fast_math), $.fcmp_cond, '(',
+      $.type_and_value, ',', $.type_and_value, ')'),
+
+    constant_extractelement: $ => seq(field('inst_name', 'extractelement'), '(',
+      $.type_and_value, ',', $.type_and_value, ')'),
+    constant_insertelement: $ => seq(field('inst_name', 'insertelement'), '(',
+      $.type_and_value, ',', $.type_and_value, ',', $.type_and_value, ')'),
+    constant_shufflevector: $ => seq(field('inst_name', 'shufflevector'), '(',
+      $.type_and_value, ',', $.type_and_value, ',', $.type_and_value, ')'),
+    constant_extractvalue: $ => seq(field('inst_name', 'extractvalue'), '(',
+      $.type_and_value, ',', commaSep1($.number), ')'),
+    constant_insertvalue: $ => seq(field('inst_name', 'insertvalue'), '(',
+      $.type_and_value, ',', $.type_and_value, ',', commaSep1($.number), ')'),
+
+    constant_fneg: $ => seq(field('inst_name', 'fneg'),
+      repeat($.fast_math), '(', $.type_and_value, ')'),
+
+    constant_bin_op: $ => seq(field('inst_name', $.bin_op_keyword),
+      repeat(choice('nsw', 'nuw', 'exact', $.fast_math)), '(', $.type_and_value, ',', $.type_and_value, ')'),
+
+    bin_op_keyword: $ => choice(
+      $.atomic_bin_op_keyword,
+      'mul',
+      'urem',
+      'srem',
+      'shl',
+      'udiv',
+      'sdiv',
+      'lshr',
+      'ashr',
+      'fmul',
+      'fdiv',
+      'frem',
+    ),
+
+    atomic_bin_op_keyword: $ => choice(
+      'xchg',
+      'add',
+      'sub',
+      'and',
+      'nand',
+      'or',
+      'xor',
+      'max',
+      'min',
+      'umax',
+      'umin',
+      'fadd',
+      'fsub',
+    ),
+
+    icmp_cond: $ => choice('eq', 'ne', 'ugt', 'uge', 'ult', 'ule', 'sgt', 'sge', 'slt', 'sle'),
+    fcmp_cond: $ => choice('false', 'oeq', 'ogt', 'oge', 'olt', 'ole', 'one', 'ord', 'ueq', 'ugt', 'uge', 'ult', 'ule', 'une', 'uno', 'true'),
+    cast_inst: $ => choice('bitcast', 'trunc', 'zext', 'sext', 'fptrunc', 'fpext', 'addrspacecast', 'uitofp', 'sitofp', 'fptoui', 'fptosi', 'inttoptr', 'ptrtoint'),
+
+    atomic_ordering: $ => choice('unordered', 'monotonic', 'acquire', 'release', 'acq_rel', 'seq_cst'),
+
+    alignment: $ => seq(
+      'align',
+      $.number,
+    ),
+
+    _load_store_suffix: $ => seq(
+      $.type_and_value,
+      optional($.syncscope),
+      optional($.atomic_ordering),
+      optional(seq(',', 'align', $.number)),
+    ),
+
+    syncscope: $ => seq(
+      'syncscope',
+      '(',
+      $.string,
+      ')',
+    ),
+
+    fast_math: $ => choice(
+      'nnan',
+      'ninf',
+      'nsz',
+      'arcp',
+      'contract',
+      'afn',
+      'reassoc',
+      'fast',
+    ),
+
+    _value_array: $ => seq(
+      '[',
+      commaSep($.type_and_value),
+      ']',
+    ),
+
+    _within: $ => seq(
+      'within',
+      choice('none', $.local_var),
+    ),
+
+    _unwind_label: $ => seq(
+      'unwind',
+      choice(seq('to', 'caller'), $.type_and_value),
+    ),
+
+    use_list_order: $ => seq(
+      'uselistorder',
+      $.type_and_value,
+      ',',
+      '{',
+      commaSep($.number),
+      '}',
+    ),
+
+    use_list_order_bb: $ => seq(
+      'uselistorder_bb',
+      $.global_var,
+      ',',
+      $.local_var,
+      ',',
+      '{',
+      commaSep($.number),
+      '}',
+    ),
+
+    module_asm: $ => seq(
+      'module',
+      'asm',
+      $.asm,
+    ),
+
+    inline_asm: $ => seq(
+      'asm',
+      optional('sideeffect'),
+      optional('alignstack'),
+      optional('inteldialect'),
+      optional('unwind'),
+      $.asm,
+      ',',
+      $.string,
+    ),
+
+    asm: $ => $.string,
+
+    global_type: $ => seq($.local_var, '=', 'type', $.type),
+
+    _global_prefix: $ => seq(
+      $.global_var, '=', repeat($.linkage), optional($.thread_local),
+      optional($.unnamed_addr), optional($.addrspace), optional('externally_initialized'),
+    ),
+
+    global_global: $ => seq(
+      $._global_prefix,
+      choice('global', 'constant'), $.type_and_value,
+      repeat(seq(optional(','), $.attribute)),
+      repeat($.metadata_refs),
+    ),
+
+    alias: $ => seq(
+      $._global_prefix,
+      'alias', $.type, ',', optional($.type), choice($.global_var, $.constant_expr),
+      repeat(seq(optional(','), $.attribute)),
+      repeat($.metadata_refs),
+    ),
+
+    ifunc: $ => seq(
+      $._global_prefix,
+      'ifunc', $.type, ',', optional($.type), choice($.global_var, $.constant_expr),
+      repeat(seq(optional(','), $.attribute)),
+      repeat($.metadata_refs),
+    ),
+
+    thread_local: $ => seq(
+      'thread_local',
+      optional(seq(
+        '(',
+        choice('localdynamic', 'initialexec', 'localexec'),
+        ')',
+      )),
+    ),
+
+    comdat: $ => seq(
+      $.comdat_ref,
+      '=',
+      'comdat',
+      choice('any', 'exactmatch', 'largest', 'nodeduplicate', 'samesize'),
+    ),
+
+    global_metadata: $ => seq(
+      $.metadata_ref,
+      '=',
+      optional('distinct'),
+      $.metadata
+    ),
+
+    metadata: $ => choice(
+      $.type_and_value,
+      $.specialized_md,
+      $.metadata_tuple,
+      'null',
+      seq('!', $.string),
+    ),
+
+    metadata_tuple: $ => seq(
+      '!',
+      token.immediate('{'),
+      commaSep($.metadata),
+      '}',
+    ),
+
+    specialized_md: $ => seq(
+      $.metadata_ref,
+      // Can be named md or specialized md
+      optional(seq(
+        token.immediate('('),
+        repeat($.specialized_md_value),
+        ')',
+      )),
+    ),
+
+    specialized_md_value: $ => choice(
+      /[-a-zA-Z0-9_.$\\]+/,
+      '|',
+      ':',
+      ',',
+      '*',
+      $._primitive_value,
+      $.var,
+      $.type_keyword,
+      $.addrspace,
+      $.metadata_tuple,
+      $.specialized_md,
+      seq('{', repeat($.specialized_md_value), '}'),
+      seq('(', repeat($.specialized_md_value), ')'),
+      seq('[', repeat($.specialized_md_value), ']'),
+      seq('<', repeat($.specialized_md_value), '>'),
+    ),
+
+    summary_entry: $ => seq(
+      $.summary_ref,
+      '=',
+      field('name', /[-a-zA-Z0-9_.$\\]+/),
+      ':',
       choice(
-        /[%@!]\d+/,
-        /[%@!][-a-zA-Z$._][-a-zA-Z$._0-9]*/,
-        /DW_TAG_[a-z_]+/,
-        /DW_ATE_[a-zA-Z_]+/,
-        /DW_OP_[a-zA-Z0-9_]+/,
-        /DW_LANG_[a-zA-Z0-9_]+/,
-        /DW_VIRTUALITY_[a-z_]+/,
-        /DIFlag[A-Za-z]+/
+        seq('(', repeat($.summary_value), ')'),
+        $.number,
+        $.string,
+        $.summary_ref,
       ),
+    ),
 
-    symbol: ($) =>
-      choice(",", "!", "=", "*", ":", "~", "^", ":", "-", "+", "|", "...", "x"),
+    summary_value: $ => choice(
+      /[-a-zA-Z0-9_.$\\]+/,
+      ':',
+      ',',
+      $.attribute_name,
+      $.string,
+      $.number,
+      $.summary_ref,
+      $.linkage_aux,
+      seq('[', repeat($.summary_value), ']'),
+      seq('(', repeat($.summary_value), ')'),
+    ),
 
-    bracket: ($) => choice("(", ")", "[", "]", "{", "}"),
+    unnamed_attr_grp: $ => seq(
+      'attributes',
+      $.attr_ref,
+      '=',
+      '{',
+      repeat($.attribute),
+      '}',
+    ),
   },
 });
+
+function commaSep(rule) {
+  return optional(commaSep1(rule));
+}
+
+function commaSep1(rule) {
+  return seq(rule, repeat(seq(',', rule)));
+}
+
+function orSep(rule) {
+  return optional(orSep1(rule));
+}
+
+function orSep1(rule) {
+  return seq(rule, repeat(seq('|', rule)));
+}

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,14 +1,156 @@
 (type) @type
-(statement) @keyword.operator
-(number) @number
+(type_keyword) @type.builtin
+
+(type [
+    (local_var)
+    (global_var)
+  ] @type)
+
+(argument) @variable.parameter
+
+(_ inst_name: _ @keyword.operator)
+
+[
+  "catch"
+  "filter"
+] @keyword.operator
+
+[
+  "to"
+  "nuw"
+  "nsw"
+  "exact"
+  "unwind"
+  "from"
+  "cleanup"
+  "swifterror"
+  "volatile"
+  "inbounds"
+  "inrange"
+] @keyword.control
+(icmp_cond) @keyword.control
+(fcmp_cond) @keyword.control
+
+(fast_math) @keyword.control
+
+(_ callee: _ @function)
+(function_header name: _ @function)
+
+[
+  "declare"
+  "define"
+] @keyword.function
+(calling_conv) @keyword.function
+
+[
+  "target"
+  "triple"
+  "datalayout"
+  "source_filename"
+  "addrspace"
+  "blockaddress"
+  "align"
+  "syncscope"
+  "within"
+  "uselistorder"
+  "uselistorder_bb"
+  "module"
+  "asm"
+  "sideeffect"
+  "alignstack"
+  "inteldialect"
+  "unwind"
+  "type"
+  "global"
+  "constant"
+  "externally_initialized"
+  "alias"
+  "ifunc"
+  "section"
+  "comdat"
+  "thread_local"
+  "localdynamic"
+  "initialexec"
+  "localexec"
+  "any"
+  "exactmatch"
+  "largest"
+  "nodeduplicate"
+  "samesize"
+  "distinct"
+  "attributes"
+  "vscale"
+  "no_cfi"
+] @keyword
+
+(linkage_aux) @keyword
+(dso_local) @keyword
+(visibility) @keyword
+(dll_storage_class) @keyword
+(unnamed_addr) @keyword
+(attribute_name) @keyword
+
+(function_header [
+    (linkage)
+    (calling_conv)
+    (unnamed_addr)
+  ] @keyword.function)
+
+(number) @constant.numeric.integer
 (comment) @comment
 (string) @string
+(cstring) @string
 (label) @label
-(keyword) @keyword
-"ret" @keyword.return
-(boolean) @boolean
-(float) @float
-(constant) @constant
-(identifier) @variable
-(symbol) @punctuation.delimiter
-(bracket) @punctuation.bracket
+(_ inst_name: "ret" @keyword.control.return)
+(float) @constant.numeric.float
+
+[
+  (local_var)
+  (global_var)
+] @variable
+
+[
+  (struct_value)
+  (array_value)
+  (vector_value)
+] @constructor
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "<"
+  ">"
+  "<{"
+  "}>"
+] @punctuation.bracket
+
+[
+  ","
+  ":"
+] @punctuation.delimiter
+
+[
+  "="
+  "|"
+  "x"
+  "..."
+] @operator
+
+[
+  "true"
+  "false"
+] @constant.builtin.boolean
+
+[
+  "undef"
+  "poison"
+  "null"
+  "none"
+  "zeroinitializer"
+] @constant.builtin
+
+(ERROR) @error

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8,60 +8,936 @@
         "members": [
           {
             "type": "SYMBOL",
-            "name": "type"
+            "name": "target_definition"
           },
           {
             "type": "SYMBOL",
-            "name": "statement"
+            "name": "source_file_name"
           },
           {
             "type": "SYMBOL",
-            "name": "number"
+            "name": "declare"
           },
           {
             "type": "SYMBOL",
-            "name": "comment"
+            "name": "define"
           },
           {
             "type": "SYMBOL",
-            "name": "string"
+            "name": "module_asm"
           },
           {
             "type": "SYMBOL",
-            "name": "label"
+            "name": "global_type"
           },
           {
             "type": "SYMBOL",
-            "name": "keyword"
+            "name": "global_global"
           },
           {
             "type": "SYMBOL",
-            "name": "boolean"
+            "name": "alias"
           },
           {
             "type": "SYMBOL",
-            "name": "float"
+            "name": "ifunc"
           },
           {
             "type": "SYMBOL",
-            "name": "constant"
+            "name": "comdat"
           },
           {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "global_metadata"
           },
           {
             "type": "SYMBOL",
-            "name": "symbol"
+            "name": "summary_entry"
           },
           {
             "type": "SYMBOL",
-            "name": "bracket"
+            "name": "unnamed_attr_grp"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "use_list_order"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "use_list_order_bb"
           }
         ]
       }
     },
+    "comment": {
+      "type": "PATTERN",
+      "value": ";.*"
+    },
+    "attr_ref": {
+      "type": "PATTERN",
+      "value": "#[0-9]+"
+    },
+    "comdat_ref": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "$"
+          },
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[-a-zA-Z$._][-a-zA-Z$._0-9]*"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\d+"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\"[^\"]*\""
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "global_var": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "@"
+          },
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[-a-zA-Z$._][-a-zA-Z$._0-9]*"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\d+"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\"[^\"]*\""
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "local_var": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "%"
+          },
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[-a-zA-Z$._][-a-zA-Z$._0-9]*"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\d+"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\"[^\"]*\""
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "label": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "[-a-zA-Z$._][-a-zA-Z$._0-9]*"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\d+"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\"[^\"]*\""
+              }
+            ]
+          },
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "STRING",
+              "value": ":"
+            }
+          }
+        ]
+      }
+    },
+    "metadata_ref": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "!"
+          },
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[-a-zA-Z$._\\\\][-a-zA-Z$._0-9\\\\]*"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\d+"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\"[^\"]*\""
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "metadata_name": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "!"
+          },
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[-a-zA-Z$._\\\\][-a-zA-Z$._0-9\\\\]*"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\d+"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\"[^\"]*\""
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "summary_ref": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "^"
+          },
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[-a-zA-Z$._][-a-zA-Z$._0-9]*"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\\d+"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "\"[^\"]*\""
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "string": {
+      "type": "PATTERN",
+      "value": "\"[^\"]*\""
+    },
+    "number": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PATTERN",
+          "value": "[+-]?\\d+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[su]?0x[KMLHR]?[0-9a-fA-F]+"
+        }
+      ]
+    },
+    "float": {
+      "type": "PATTERN",
+      "value": "[+-]?\\d+\\.\\d*([Ee][+-]?\\d+)?"
+    },
+    "cstring": {
+      "type": "PATTERN",
+      "value": "c\"[^\"]*\""
+    },
+    "var": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "local_var"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "global_var"
+        }
+      ]
+    },
+    "target_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "target"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "target_triple"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "data_layout"
+            }
+          ]
+        }
+      ]
+    },
+    "target_triple": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "triple"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        }
+      ]
+    },
+    "data_layout": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "datalayout"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        }
+      ]
+    },
+    "source_file_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "source_filename"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        }
+      ]
+    },
+    "declare": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "declare"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "metadata_attachment"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_header"
+        }
+      ]
+    },
+    "define": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "define"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_header"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "metadata_attachment"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "function_body"
+          }
+        }
+      ]
+    },
+    "metadata_attachment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "metadata_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "metadata"
+        }
+      ]
+    },
+    "function_header": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "linkage"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "calling_conv"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "param_or_return_attrs"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "unnamed_addr"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "global_var"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "arguments",
+          "content": {
+            "type": "SYMBOL",
+            "name": "argument_list"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "unnamed_addr"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "addrspace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute"
+          }
+        }
+      ]
+    },
+    "linkage": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "linkage_aux"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dso_local"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "visibility"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dll_storage_class"
+        },
+        {
+          "type": "STRING",
+          "value": "no_cfi"
+        }
+      ]
+    },
+    "linkage_aux": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "private"
+        },
+        {
+          "type": "STRING",
+          "value": "internal"
+        },
+        {
+          "type": "STRING",
+          "value": "weak"
+        },
+        {
+          "type": "STRING",
+          "value": "weak_odr"
+        },
+        {
+          "type": "STRING",
+          "value": "linkonce"
+        },
+        {
+          "type": "STRING",
+          "value": "linkonce_odr"
+        },
+        {
+          "type": "STRING",
+          "value": "available_externally"
+        },
+        {
+          "type": "STRING",
+          "value": "appending"
+        },
+        {
+          "type": "STRING",
+          "value": "common"
+        },
+        {
+          "type": "STRING",
+          "value": "extern_weak"
+        },
+        {
+          "type": "STRING",
+          "value": "external"
+        }
+      ]
+    },
+    "dso_local": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "dso_local"
+        },
+        {
+          "type": "STRING",
+          "value": "dso_local_equivalent"
+        },
+        {
+          "type": "STRING",
+          "value": "dso_preemptable"
+        }
+      ]
+    },
+    "visibility": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "default"
+        },
+        {
+          "type": "STRING",
+          "value": "hidden"
+        },
+        {
+          "type": "STRING",
+          "value": "protected"
+        }
+      ]
+    },
+    "dll_storage_class": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "dllimport"
+        },
+        {
+          "type": "STRING",
+          "value": "dllexport"
+        }
+      ]
+    },
+    "calling_conv": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "ccc"
+        },
+        {
+          "type": "STRING",
+          "value": "fastcc"
+        },
+        {
+          "type": "STRING",
+          "value": "coldcc"
+        },
+        {
+          "type": "STRING",
+          "value": "webkit_jscc"
+        },
+        {
+          "type": "STRING",
+          "value": "anyregcc"
+        },
+        {
+          "type": "STRING",
+          "value": "preserve_mostcc"
+        },
+        {
+          "type": "STRING",
+          "value": "preserve_allcc"
+        },
+        {
+          "type": "STRING",
+          "value": "cxx_fast_tlscc"
+        },
+        {
+          "type": "STRING",
+          "value": "tailcc"
+        },
+        {
+          "type": "STRING",
+          "value": "swiftcc"
+        },
+        {
+          "type": "STRING",
+          "value": "swifttailcc"
+        },
+        {
+          "type": "STRING",
+          "value": "cfguard_checkcc"
+        },
+        {
+          "type": "PATTERN",
+          "value": "x86_[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "arm_[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "aarch64_[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "msp430_[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "avr_[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "ptx_[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "spir_[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "intel_[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "win[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "webkit_[a-z_0-9]+"
+        },
+        {
+          "type": "STRING",
+          "value": "ghccc"
+        },
+        {
+          "type": "PATTERN",
+          "value": "swift[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "hhvm[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "cxx_[a-z_0-9]+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "amdgpu_[a-z_0-9]+"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "cc"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "number"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        }
+      ]
+    },
+    "unnamed_addr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "unnamed_addr"
+        },
+        {
+          "type": "STRING",
+          "value": "local_unnamed_addr"
+        }
+      ]
+    },
     "type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_keyword"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "struct_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "packed_struct_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "array_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "vector_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "local_var"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "addrspace"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "*"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "SYMBOL",
+                "name": "argument_list"
+              }
+            ]
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "addrspace"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "*"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "addrspace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "type_keyword": {
       "type": "CHOICE",
       "members": [
         {
@@ -94,7 +970,7 @@
         },
         {
           "type": "STRING",
-          "value": "pcc_fp128"
+          "value": "ppc_fp128"
         },
         {
           "type": "STRING",
@@ -113,451 +989,616 @@
           "value": "x86_amx"
         },
         {
+          "type": "STRING",
+          "value": "token"
+        },
+        {
+          "type": "STRING",
+          "value": "opaque"
+        },
+        {
+          "type": "STRING",
+          "value": "ptr"
+        },
+        {
           "type": "PATTERN",
           "value": "i\\d+"
         }
       ]
     },
-    "statement": {
-      "type": "CHOICE",
+    "struct_type": {
+      "type": "SEQ",
       "members": [
         {
           "type": "STRING",
-          "value": "add"
+          "value": "{"
         },
         {
-          "type": "STRING",
-          "value": "addrspacecast"
-        },
-        {
-          "type": "STRING",
-          "value": "alloca"
-        },
-        {
-          "type": "STRING",
-          "value": "and"
-        },
-        {
-          "type": "STRING",
-          "value": "arcp"
-        },
-        {
-          "type": "STRING",
-          "value": "ashr"
-        },
-        {
-          "type": "STRING",
-          "value": "atomicrmw"
-        },
-        {
-          "type": "STRING",
-          "value": "bitcast"
-        },
-        {
-          "type": "STRING",
-          "value": "br"
-        },
-        {
-          "type": "STRING",
-          "value": "catchpad"
-        },
-        {
-          "type": "STRING",
-          "value": "catchswitch"
-        },
-        {
-          "type": "STRING",
-          "value": "catchret"
-        },
-        {
-          "type": "STRING",
-          "value": "call"
-        },
-        {
-          "type": "STRING",
-          "value": "callbr"
-        },
-        {
-          "type": "STRING",
-          "value": "cleanuppad"
-        },
-        {
-          "type": "STRING",
-          "value": "cleanupret"
-        },
-        {
-          "type": "STRING",
-          "value": "cmpxchg"
-        },
-        {
-          "type": "STRING",
-          "value": "eq"
-        },
-        {
-          "type": "STRING",
-          "value": "exact"
-        },
-        {
-          "type": "STRING",
-          "value": "extractelement"
-        },
-        {
-          "type": "STRING",
-          "value": "extractvalue"
-        },
-        {
-          "type": "STRING",
-          "value": "fadd"
-        },
-        {
-          "type": "STRING",
-          "value": "fast"
-        },
-        {
-          "type": "STRING",
-          "value": "fcmp"
-        },
-        {
-          "type": "STRING",
-          "value": "fdiv"
-        },
-        {
-          "type": "STRING",
-          "value": "fence"
-        },
-        {
-          "type": "STRING",
-          "value": "fmul"
-        },
-        {
-          "type": "STRING",
-          "value": "fneg"
-        },
-        {
-          "type": "STRING",
-          "value": "fpext"
-        },
-        {
-          "type": "STRING",
-          "value": "fptosi"
-        },
-        {
-          "type": "STRING",
-          "value": "fptoui"
-        },
-        {
-          "type": "STRING",
-          "value": "fptrunc"
-        },
-        {
-          "type": "STRING",
-          "value": "free"
-        },
-        {
-          "type": "STRING",
-          "value": "freeze"
-        },
-        {
-          "type": "STRING",
-          "value": "frem"
-        },
-        {
-          "type": "STRING",
-          "value": "fsub"
-        },
-        {
-          "type": "STRING",
-          "value": "getelementptr"
-        },
-        {
-          "type": "STRING",
-          "value": "icmp"
-        },
-        {
-          "type": "STRING",
-          "value": "inbounds"
-        },
-        {
-          "type": "STRING",
-          "value": "indirectbr"
-        },
-        {
-          "type": "STRING",
-          "value": "insertelement"
-        },
-        {
-          "type": "STRING",
-          "value": "insertvalue"
-        },
-        {
-          "type": "STRING",
-          "value": "inttoptr"
-        },
-        {
-          "type": "STRING",
-          "value": "invoke"
-        },
-        {
-          "type": "STRING",
-          "value": "landingpad"
-        },
-        {
-          "type": "STRING",
-          "value": "load"
-        },
-        {
-          "type": "STRING",
-          "value": "lshr"
-        },
-        {
-          "type": "STRING",
-          "value": "malloc"
-        },
-        {
-          "type": "STRING",
-          "value": "max"
-        },
-        {
-          "type": "STRING",
-          "value": "min"
-        },
-        {
-          "type": "STRING",
-          "value": "mul"
-        },
-        {
-          "type": "STRING",
-          "value": "nand"
-        },
-        {
-          "type": "STRING",
-          "value": "ne"
-        },
-        {
-          "type": "STRING",
-          "value": "ninf"
-        },
-        {
-          "type": "STRING",
-          "value": "nnan"
-        },
-        {
-          "type": "STRING",
-          "value": "nsw"
-        },
-        {
-          "type": "STRING",
-          "value": "nsz"
-        },
-        {
-          "type": "STRING",
-          "value": "nuw"
-        },
-        {
-          "type": "STRING",
-          "value": "oeq"
-        },
-        {
-          "type": "STRING",
-          "value": "oge"
-        },
-        {
-          "type": "STRING",
-          "value": "ogt"
-        },
-        {
-          "type": "STRING",
-          "value": "ole"
-        },
-        {
-          "type": "STRING",
-          "value": "olt"
-        },
-        {
-          "type": "STRING",
-          "value": "one"
-        },
-        {
-          "type": "STRING",
-          "value": "or"
-        },
-        {
-          "type": "STRING",
-          "value": "ord"
-        },
-        {
-          "type": "STRING",
-          "value": "phi"
-        },
-        {
-          "type": "STRING",
-          "value": "ptrtoint"
-        },
-        {
-          "type": "STRING",
-          "value": "resume"
-        },
-        {
-          "type": "STRING",
-          "value": "ret"
-        },
-        {
-          "type": "STRING",
-          "value": "sdiv"
-        },
-        {
-          "type": "STRING",
-          "value": "select"
-        },
-        {
-          "type": "STRING",
-          "value": "sext"
-        },
-        {
-          "type": "STRING",
-          "value": "sge"
-        },
-        {
-          "type": "STRING",
-          "value": "sgt"
-        },
-        {
-          "type": "STRING",
-          "value": "shl"
-        },
-        {
-          "type": "STRING",
-          "value": "shufflevector"
-        },
-        {
-          "type": "STRING",
-          "value": "sitofp"
-        },
-        {
-          "type": "STRING",
-          "value": "sle"
-        },
-        {
-          "type": "STRING",
-          "value": "slt"
-        },
-        {
-          "type": "STRING",
-          "value": "srem"
-        },
-        {
-          "type": "STRING",
-          "value": "store"
-        },
-        {
-          "type": "STRING",
-          "value": "sub"
-        },
-        {
-          "type": "STRING",
-          "value": "switch"
-        },
-        {
-          "type": "STRING",
-          "value": "trunc"
-        },
-        {
-          "type": "STRING",
-          "value": "udiv"
-        },
-        {
-          "type": "STRING",
-          "value": "ueq"
-        },
-        {
-          "type": "STRING",
-          "value": "uge"
-        },
-        {
-          "type": "STRING",
-          "value": "ugt"
-        },
-        {
-          "type": "STRING",
-          "value": "uitofp"
-        },
-        {
-          "type": "STRING",
-          "value": "ule"
-        },
-        {
-          "type": "STRING",
-          "value": "ult"
-        },
-        {
-          "type": "STRING",
-          "value": "umax"
-        },
-        {
-          "type": "STRING",
-          "value": "umin"
-        },
-        {
-          "type": "STRING",
-          "value": "une"
-        },
-        {
-          "type": "STRING",
-          "value": "uno"
-        },
-        {
-          "type": "STRING",
-          "value": "unreachable"
-        },
-        {
-          "type": "STRING",
-          "value": "unwind"
-        },
-        {
-          "type": "STRING",
-          "value": "urem"
-        },
-        {
-          "type": "STRING",
-          "value": "va_arg"
-        },
-        {
-          "type": "STRING",
-          "value": "xchg"
-        },
-        {
-          "type": "STRING",
-          "value": "xor"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "struct_body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",
-          "value": "zext"
+          "value": "}"
         }
       ]
     },
-    "keyword": {
-      "type": "CHOICE",
+    "packed_struct_type": {
+      "type": "SEQ",
       "members": [
         {
           "type": "STRING",
-          "value": "acq_rel"
+          "value": "<{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "struct_body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",
-          "value": "acquire"
+          "value": "}>"
+        }
+      ]
+    },
+    "array_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
         },
+        {
+          "type": "SYMBOL",
+          "name": "array_vector_body"
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "vector_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array_vector_body"
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
+    },
+    "struct_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "SYMBOL",
+                "name": "type"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "array_vector_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "vscale"
+                },
+                {
+                  "type": "STRING",
+                  "value": "x"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "number"
+        },
+        {
+          "type": "STRING",
+          "value": "x"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        }
+      ]
+    },
+    "addrspace": {
+      "type": "SEQ",
+      "members": [
         {
           "type": "STRING",
           "value": "addrspace"
         },
         {
           "type": "STRING",
-          "value": "alias"
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "number"
         },
         {
           "type": "STRING",
-          "value": "align"
+          "value": ")"
+        }
+      ]
+    },
+    "argument_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
         },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "argument"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "argument"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "argument": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "metadata"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "param_or_return_attrs"
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "metadata"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "param_or_return_attrs"
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "value"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "..."
+        }
+      ]
+    },
+    "param_or_return_attrs": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "align"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "number"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "attribute_name"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "type"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "number"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "attribute": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "attribute_name"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "string"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "attr_ref"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "("
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SEQ",
+                              "members": [
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SYMBOL",
+                                      "name": "type"
+                                    },
+                                    {
+                                      "type": "SYMBOL",
+                                      "name": "number"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "REPEAT",
+                                  "content": {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": ","
+                                      },
+                                      {
+                                        "type": "CHOICE",
+                                        "members": [
+                                          {
+                                            "type": "SYMBOL",
+                                            "name": "type"
+                                          },
+                                          {
+                                            "type": "SYMBOL",
+                                            "name": "number"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ")"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "="
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "string"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "number"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "section"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "string"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "partition"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "string"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "comdat"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "comdat_ref"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alignment"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "gc"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "string"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "prefix"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type_and_value"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "prologue"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type_and_value"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "personality"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type_and_value"
+            }
+          ]
+        }
+      ]
+    },
+    "attribute_name": {
+      "type": "CHOICE",
+      "members": [
         {
           "type": "STRING",
           "value": "alignstack"
@@ -572,75 +1613,7 @@
         },
         {
           "type": "STRING",
-          "value": "appending"
-        },
-        {
-          "type": "STRING",
-          "value": "argmemonly"
-        },
-        {
-          "type": "STRING",
-          "value": "arm_aapcs_vfpcc"
-        },
-        {
-          "type": "STRING",
-          "value": "arm_aapcscc"
-        },
-        {
-          "type": "STRING",
-          "value": "arm_apcscc"
-        },
-        {
-          "type": "STRING",
-          "value": "asm"
-        },
-        {
-          "type": "STRING",
-          "value": "atomic"
-        },
-        {
-          "type": "STRING",
-          "value": "available_externally"
-        },
-        {
-          "type": "STRING",
-          "value": "blockaddress"
-        },
-        {
-          "type": "STRING",
           "value": "builtin"
-        },
-        {
-          "type": "STRING",
-          "value": "byref"
-        },
-        {
-          "type": "STRING",
-          "value": "byval"
-        },
-        {
-          "type": "STRING",
-          "value": "c"
-        },
-        {
-          "type": "STRING",
-          "value": "caller"
-        },
-        {
-          "type": "STRING",
-          "value": "catch"
-        },
-        {
-          "type": "STRING",
-          "value": "cc"
-        },
-        {
-          "type": "STRING",
-          "value": "ccc"
-        },
-        {
-          "type": "STRING",
-          "value": "cleanup"
         },
         {
           "type": "STRING",
@@ -648,119 +1621,11 @@
         },
         {
           "type": "STRING",
-          "value": "coldcc"
-        },
-        {
-          "type": "STRING",
-          "value": "comdat"
-        },
-        {
-          "type": "STRING",
-          "value": "common"
-        },
-        {
-          "type": "STRING",
-          "value": "constant"
-        },
-        {
-          "type": "STRING",
           "value": "convergent"
         },
         {
           "type": "STRING",
-          "value": "datalayout"
-        },
-        {
-          "type": "STRING",
-          "value": "declare"
-        },
-        {
-          "type": "STRING",
-          "value": "default"
-        },
-        {
-          "type": "STRING",
-          "value": "define"
-        },
-        {
-          "type": "STRING",
-          "value": "deplibs"
-        },
-        {
-          "type": "STRING",
-          "value": "dereferenceable"
-        },
-        {
-          "type": "STRING",
-          "value": "dereferenceable_or_null"
-        },
-        {
-          "type": "STRING",
-          "value": "distinct"
-        },
-        {
-          "type": "STRING",
-          "value": "dllexport"
-        },
-        {
-          "type": "STRING",
-          "value": "dllimport"
-        },
-        {
-          "type": "STRING",
-          "value": "dso_local"
-        },
-        {
-          "type": "STRING",
-          "value": "dso_preemptable"
-        },
-        {
-          "type": "STRING",
-          "value": "except"
-        },
-        {
-          "type": "STRING",
-          "value": "extern_weak"
-        },
-        {
-          "type": "STRING",
-          "value": "external"
-        },
-        {
-          "type": "STRING",
-          "value": "externally_initialized"
-        },
-        {
-          "type": "STRING",
-          "value": "fastcc"
-        },
-        {
-          "type": "STRING",
-          "value": "filter"
-        },
-        {
-          "type": "STRING",
-          "value": "from"
-        },
-        {
-          "type": "STRING",
-          "value": "gc"
-        },
-        {
-          "type": "STRING",
-          "value": "global"
-        },
-        {
-          "type": "STRING",
-          "value": "hhvm_ccc"
-        },
-        {
-          "type": "STRING",
-          "value": "hhvmcc"
-        },
-        {
-          "type": "STRING",
-          "value": "hidden"
+          "value": "disable_sanitizer_instrumentation"
         },
         {
           "type": "STRING",
@@ -768,7 +1633,7 @@
         },
         {
           "type": "STRING",
-          "value": "immarg"
+          "value": "inaccessiblememonly"
         },
         {
           "type": "STRING",
@@ -776,35 +1641,7 @@
         },
         {
           "type": "STRING",
-          "value": "inaccessiblememonly"
-        },
-        {
-          "type": "STRING",
-          "value": "inalloca"
-        },
-        {
-          "type": "STRING",
-          "value": "initialexec"
-        },
-        {
-          "type": "STRING",
           "value": "inlinehint"
-        },
-        {
-          "type": "STRING",
-          "value": "inreg"
-        },
-        {
-          "type": "STRING",
-          "value": "intel_ocl_bicc"
-        },
-        {
-          "type": "STRING",
-          "value": "inteldialect"
-        },
-        {
-          "type": "STRING",
-          "value": "internal"
         },
         {
           "type": "STRING",
@@ -812,47 +1649,7 @@
         },
         {
           "type": "STRING",
-          "value": "linkonce"
-        },
-        {
-          "type": "STRING",
-          "value": "linkonce_odr"
-        },
-        {
-          "type": "STRING",
-          "value": "local_unnamed_addr"
-        },
-        {
-          "type": "STRING",
-          "value": "localdynamic"
-        },
-        {
-          "type": "STRING",
-          "value": "localexec"
-        },
-        {
-          "type": "STRING",
           "value": "minsize"
-        },
-        {
-          "type": "STRING",
-          "value": "module"
-        },
-        {
-          "type": "STRING",
-          "value": "monotonic"
-        },
-        {
-          "type": "STRING",
-          "value": "msp430_intrcc"
-        },
-        {
-          "type": "STRING",
-          "value": "mustprogress"
-        },
-        {
-          "type": "STRING",
-          "value": "musttail"
         },
         {
           "type": "STRING",
@@ -860,27 +1657,11 @@
         },
         {
           "type": "STRING",
-          "value": "nest"
-        },
-        {
-          "type": "STRING",
-          "value": "noalias"
+          "value": "no-jump-tables"
         },
         {
           "type": "STRING",
           "value": "nobuiltin"
-        },
-        {
-          "type": "STRING",
-          "value": "nocallback"
-        },
-        {
-          "type": "STRING",
-          "value": "nocapture"
-        },
-        {
-          "type": "STRING",
-          "value": "nocf_check"
         },
         {
           "type": "STRING",
@@ -908,15 +1689,7 @@
         },
         {
           "type": "STRING",
-          "value": "nonnull"
-        },
-        {
-          "type": "STRING",
           "value": "noprofile"
-        },
-        {
-          "type": "STRING",
-          "value": "norecurse"
         },
         {
           "type": "STRING",
@@ -924,15 +1697,23 @@
         },
         {
           "type": "STRING",
+          "value": "indirect-tls-seg-refs"
+        },
+        {
+          "type": "STRING",
           "value": "noreturn"
         },
         {
           "type": "STRING",
-          "value": "nosync"
+          "value": "norecurse"
         },
         {
           "type": "STRING",
-          "value": "noundef"
+          "value": "willreturn"
+        },
+        {
+          "type": "STRING",
+          "value": "nosync"
         },
         {
           "type": "STRING",
@@ -960,30 +1741,6 @@
         },
         {
           "type": "STRING",
-          "value": "personality"
-        },
-        {
-          "type": "STRING",
-          "value": "preallocated"
-        },
-        {
-          "type": "STRING",
-          "value": "private"
-        },
-        {
-          "type": "STRING",
-          "value": "protected"
-        },
-        {
-          "type": "STRING",
-          "value": "ptx_device"
-        },
-        {
-          "type": "STRING",
-          "value": "ptx_kernel"
-        },
-        {
-          "type": "STRING",
           "value": "readnone"
         },
         {
@@ -992,11 +1749,11 @@
         },
         {
           "type": "STRING",
-          "value": "release"
+          "value": "writeonly"
         },
         {
           "type": "STRING",
-          "value": "returned"
+          "value": "argmemonly"
         },
         {
           "type": "STRING",
@@ -1012,15 +1769,7 @@
         },
         {
           "type": "STRING",
-          "value": "sanitize_hwaddress"
-        },
-        {
-          "type": "STRING",
           "value": "sanitize_memory"
-        },
-        {
-          "type": "STRING",
-          "value": "sanitize_memtag"
         },
         {
           "type": "STRING",
@@ -1028,31 +1777,11 @@
         },
         {
           "type": "STRING",
-          "value": "section"
+          "value": "sanitize_hwaddress"
         },
         {
           "type": "STRING",
-          "value": "seq_cst"
-        },
-        {
-          "type": "STRING",
-          "value": "shadowcallstack"
-        },
-        {
-          "type": "STRING",
-          "value": "sideeffect"
-        },
-        {
-          "type": "STRING",
-          "value": "signext"
-        },
-        {
-          "type": "STRING",
-          "value": "source_filename"
-        },
-        {
-          "type": "STRING",
-          "value": "speculatable"
+          "value": "sanitize_memtag"
         },
         {
           "type": "STRING",
@@ -1060,15 +1789,7 @@
         },
         {
           "type": "STRING",
-          "value": "spir_func"
-        },
-        {
-          "type": "STRING",
-          "value": "spir_kernel"
-        },
-        {
-          "type": "STRING",
-          "value": "sret"
+          "value": "speculatable"
         },
         {
           "type": "STRING",
@@ -1076,11 +1797,11 @@
         },
         {
           "type": "STRING",
-          "value": "sspreq"
+          "value": "sspstrong"
         },
         {
           "type": "STRING",
-          "value": "sspstrong"
+          "value": "sspreq"
         },
         {
           "type": "STRING",
@@ -1088,15 +1809,91 @@
         },
         {
           "type": "STRING",
-          "value": "swiftcc"
+          "value": "uwtable"
         },
         {
           "type": "STRING",
-          "value": "swifterror"
+          "value": "nocf_check"
         },
         {
           "type": "STRING",
-          "value": "swifttailcc"
+          "value": "shadowcallstack"
+        },
+        {
+          "type": "STRING",
+          "value": "mustprogress"
+        },
+        {
+          "type": "STRING",
+          "value": "vscale_range"
+        },
+        {
+          "type": "STRING",
+          "value": "preallocated"
+        },
+        {
+          "type": "STRING",
+          "value": "zeroext"
+        },
+        {
+          "type": "STRING",
+          "value": "signext"
+        },
+        {
+          "type": "STRING",
+          "value": "inreg"
+        },
+        {
+          "type": "STRING",
+          "value": "byval"
+        },
+        {
+          "type": "STRING",
+          "value": "byref"
+        },
+        {
+          "type": "STRING",
+          "value": "inalloca"
+        },
+        {
+          "type": "STRING",
+          "value": "sret"
+        },
+        {
+          "type": "STRING",
+          "value": "elementtype"
+        },
+        {
+          "type": "STRING",
+          "value": "align"
+        },
+        {
+          "type": "STRING",
+          "value": "noalias"
+        },
+        {
+          "type": "STRING",
+          "value": "nocapture"
+        },
+        {
+          "type": "STRING",
+          "value": "nest"
+        },
+        {
+          "type": "STRING",
+          "value": "returned"
+        },
+        {
+          "type": "STRING",
+          "value": "nonnull"
+        },
+        {
+          "type": "STRING",
+          "value": "dereferenceable"
+        },
+        {
+          "type": "STRING",
+          "value": "dereferenceable_or_null"
         },
         {
           "type": "STRING",
@@ -1104,120 +1901,1882 @@
         },
         {
           "type": "STRING",
-          "value": "syncscope"
+          "value": "swiftasync"
         },
         {
           "type": "STRING",
-          "value": "tail"
+          "value": "swifterror"
         },
         {
           "type": "STRING",
-          "value": "tailcc"
+          "value": "immarg"
         },
         {
           "type": "STRING",
-          "value": "target"
+          "value": "noundef"
+        }
+      ]
+    },
+    "function_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "label"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "instruction"
+              }
+            ]
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "use_list_order"
+          }
         },
         {
           "type": "STRING",
-          "value": "thread_local"
+          "value": "}"
+        }
+      ]
+    },
+    "instruction": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "local_var"
+                },
+                {
+                  "type": "STRING",
+                  "value": "="
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_instruction_body"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "metadata_refs"
+          }
+        }
+      ]
+    },
+    "_instruction_body": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "instruction_unreachable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_ret"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_br"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_resume"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_freeze"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_indirectbr"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_extractelement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_insertelement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_select"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_shufflevector"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_fneg"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_bin_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_switch"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_invoke"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_cleanupret"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_catchret"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_catchswitch"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_catchpad"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_cleanuppad"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_callbr"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_icmp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_fcmp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_cast"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_va_arg"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_phi"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_landingpad"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_call"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_alloca"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_load"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_store"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_cmpxchg"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_atomicrmw"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_fence"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_getelementptr"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_extractvalue"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instruction_insertvalue"
+        }
+      ]
+    },
+    "instruction_unreachable": {
+      "type": "FIELD",
+      "name": "inst_name",
+      "content": {
+        "type": "STRING",
+        "value": "unreachable"
+      }
+    },
+    "instruction_ret": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "ret"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        }
+      ]
+    },
+    "instruction_br": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "br"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "type_and_value"
+                },
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "type_and_value"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "instruction_resume": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "resume"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        }
+      ]
+    },
+    "instruction_freeze": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "freeze"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        }
+      ]
+    },
+    "instruction_indirectbr": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "indirectbr"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_value_array"
+        }
+      ]
+    },
+    "instruction_extractelement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "extractelement"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        }
+      ]
+    },
+    "instruction_insertelement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "insertelement"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        }
+      ]
+    },
+    "instruction_select": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "select"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "fast_math"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        }
+      ]
+    },
+    "instruction_shufflevector": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "shufflevector"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        }
+      ]
+    },
+    "instruction_fneg": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "fneg"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "fast_math"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        }
+      ]
+    },
+    "instruction_bin_op": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "bin_op_keyword"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "nsw"
+              },
+              {
+                "type": "STRING",
+                "value": "nuw"
+              },
+              {
+                "type": "STRING",
+                "value": "exact"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "fast_math"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "value"
+        }
+      ]
+    },
+    "instruction_switch": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "switch"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "type_and_value"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "SYMBOL",
+                "name": "type_and_value"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "instruction_invoke": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "invoke"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_call_part"
         },
         {
           "type": "STRING",
           "value": "to"
         },
         {
-          "type": "STRING",
-          "value": "triple"
+          "type": "SYMBOL",
+          "name": "type_and_value"
         },
         {
           "type": "STRING",
-          "value": "unnamed_addr"
+          "value": "unwind"
         },
         {
-          "type": "STRING",
-          "value": "unordered"
-        },
-        {
-          "type": "STRING",
-          "value": "uselistorder"
-        },
-        {
-          "type": "STRING",
-          "value": "uselistorder_bb"
-        },
-        {
-          "type": "STRING",
-          "value": "uwtable"
-        },
-        {
-          "type": "STRING",
-          "value": "volatile"
-        },
-        {
-          "type": "STRING",
-          "value": "weak"
-        },
-        {
-          "type": "STRING",
-          "value": "weak_odr"
-        },
-        {
-          "type": "STRING",
-          "value": "willreturn"
-        },
-        {
-          "type": "STRING",
-          "value": "win64cc"
-        },
-        {
-          "type": "STRING",
-          "value": "within"
-        },
-        {
-          "type": "STRING",
-          "value": "writeonly"
-        },
-        {
-          "type": "STRING",
-          "value": "x86_64_sysvcc"
-        },
-        {
-          "type": "STRING",
-          "value": "x86_fastcallcc"
-        },
-        {
-          "type": "STRING",
-          "value": "x86_stdcallcc"
-        },
-        {
-          "type": "STRING",
-          "value": "x86_thiscallcc"
-        },
-        {
-          "type": "STRING",
-          "value": "zeroext"
+          "type": "SYMBOL",
+          "name": "type_and_value"
         }
       ]
     },
-    "number": {
-      "type": "PATTERN",
-      "value": "-?\\d+"
+    "instruction_cleanupret": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "cleanupret"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "from"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "local_var"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_unwind_label"
+        }
+      ]
     },
-    "float": {
+    "instruction_catchret": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "catchret"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "from"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "local_var"
+        },
+        {
+          "type": "STRING",
+          "value": "to"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        }
+      ]
+    },
+    "instruction_catchswitch": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "catchswitch"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_within"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_value_array"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_unwind_label"
+        }
+      ]
+    },
+    "instruction_catchpad": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "catchpad"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_within"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_value_array"
+        }
+      ]
+    },
+    "instruction_cleanuppad": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "cleanuppad"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_within"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_value_array"
+        }
+      ]
+    },
+    "instruction_callbr": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "callbr"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_call_part"
+        },
+        {
+          "type": "STRING",
+          "value": "to"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "["
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "type_and_value"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "type_and_value"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "]"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "instruction_icmp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "icmp"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "icmp_cond"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "value"
+        }
+      ]
+    },
+    "instruction_fcmp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "fcmp"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "fast_math"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "fcmp_cond"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "value"
+        }
+      ]
+    },
+    "instruction_cast": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "cast_inst"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": "to"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        }
+      ]
+    },
+    "instruction_va_arg": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "va_arg"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        }
+      ]
+    },
+    "instruction_phi": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "phi"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "fast_math"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "["
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "value"
+                },
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "local_var"
+                },
+                {
+                  "type": "STRING",
+                  "value": "]"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "["
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "value"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "local_var"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "instruction_landingpad": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "landingpad"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "landingpad_clause"
+            },
+            {
+              "type": "STRING",
+              "value": "cleanup"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "landingpad_clause"
+          }
+        }
+      ]
+    },
+    "instruction_call": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "tail"
+                },
+                {
+                  "type": "STRING",
+                  "value": "musttail"
+                },
+                {
+                  "type": "STRING",
+                  "value": "notail"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "call"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "fast_math"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_call_part"
+        }
+      ]
+    },
+    "instruction_alloca": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "alloca"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "inalloca"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "swifterror"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "type_and_value"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "alignment"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "addrspace"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "instruction_load": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "load"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "atomic"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "volatile"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_load_store_suffix"
+        }
+      ]
+    },
+    "instruction_store": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "store"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "atomic"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "volatile"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_load_store_suffix"
+        }
+      ]
+    },
+    "instruction_cmpxchg": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "cmpxchg"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "weak"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "volatile"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "syncscope"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "atomic_ordering"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "atomic_ordering"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "alignment"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "instruction_atomicrmw": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "atomicrmw"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "volatile"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "atomic_bin_op_keyword"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "syncscope"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "atomic_ordering"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "alignment"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "instruction_fence": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "fence"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "syncscope"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "atomic_ordering"
+        }
+      ]
+    },
+    "instruction_getelementptr": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "getelementptr"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "inbounds"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "inrange"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "type_and_value"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "inrange"
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "type_and_value"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "instruction_extractvalue": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "extractvalue"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "number"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "number"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "instruction_insertvalue": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "insertvalue"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "number"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "number"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "_call_part": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "calling_conv"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "param_or_return_attrs"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "addrspace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "FIELD",
+          "name": "callee",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "value"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "inline_asm"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "arguments",
+          "content": {
+            "type": "SYMBOL",
+            "name": "argument_list"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "operand_bundles"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "type_and_value": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "PATTERN",
-          "value": "-?\\d+\\.\\d*(e[+-]\\d+)\\?"
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "metadata"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "metadata"
+              }
+            ]
+          }
         },
         {
-          "type": "PATTERN",
-          "value": "0x[0-9a-fA-F]+"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "value"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
-    "boolean": {
+    "value": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "linkage"
+              }
+            },
+            {
+              "type": "SYMBOL",
+              "name": "var"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_primitive_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "struct_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "packed_struct_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "vector_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "blockaddress"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_expr"
+        }
+      ]
+    },
+    "_primitive_value": {
       "type": "CHOICE",
       "members": [
         {
@@ -1227,19 +3786,6 @@
         {
           "type": "STRING",
           "value": "false"
-        }
-      ]
-    },
-    "constant": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "zeroinitializer"
-        },
-        {
-          "type": "STRING",
-          "value": "undef"
         },
         {
           "type": "STRING",
@@ -1251,73 +3797,1794 @@
         },
         {
           "type": "STRING",
+          "value": "undef"
+        },
+        {
+          "type": "STRING",
           "value": "poison"
         },
         {
           "type": "STRING",
-          "value": "vscale"
+          "value": "zeroinitializer"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "cstring"
         }
       ]
     },
-    "comment": {
-      "type": "PATTERN",
-      "value": ";.*"
-    },
-    "string": {
-      "type": "PATTERN",
-      "value": "[!c]?\"(\\\\\\\\|\\\\\"|.)*\""
-    },
-    "label": {
-      "type": "PATTERN",
-      "value": "[-a-zA-Z$._][-a-zA-Z$._0-9]*:"
-    },
-    "identifier": {
-      "type": "CHOICE",
+    "struct_value": {
+      "type": "SEQ",
       "members": [
         {
-          "type": "PATTERN",
-          "value": "[%@!]\\d+"
+          "type": "STRING",
+          "value": "{"
         },
         {
-          "type": "PATTERN",
-          "value": "[%@!][-a-zA-Z$._][-a-zA-Z$._0-9]*"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "type_and_value"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "type_and_value"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
-          "type": "PATTERN",
-          "value": "DW_TAG_[a-z_]+"
-        },
-        {
-          "type": "PATTERN",
-          "value": "DW_ATE_[a-zA-Z_]+"
-        },
-        {
-          "type": "PATTERN",
-          "value": "DW_OP_[a-zA-Z0-9_]+"
-        },
-        {
-          "type": "PATTERN",
-          "value": "DW_LANG_[a-zA-Z0-9_]+"
-        },
-        {
-          "type": "PATTERN",
-          "value": "DW_VIRTUALITY_[a-z_]+"
-        },
-        {
-          "type": "PATTERN",
-          "value": "DIFlag[A-Za-z]+"
+          "type": "STRING",
+          "value": "}"
         }
       ]
     },
-    "symbol": {
-      "type": "CHOICE",
+    "packed_struct_value": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "type_and_value"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "type_and_value"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}>"
+        }
+      ]
+    },
+    "array_value": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "type_and_value"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "type_and_value"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "vector_value": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "type_and_value"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "type_and_value"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
+    },
+    "metadata_refs": {
+      "type": "SEQ",
       "members": [
         {
           "type": "STRING",
           "value": ","
         },
         {
+          "type": "SYMBOL",
+          "name": "metadata_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "metadata"
+        }
+      ]
+    },
+    "operand_bundles": {
+      "type": "SEQ",
+      "members": [
+        {
           "type": "STRING",
-          "value": "!"
+          "value": "["
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "string"
+                },
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "type_and_value"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "type_and_value"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "string"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "("
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "type_and_value"
+                              },
+                              {
+                                "type": "REPEAT",
+                                "content": {
+                                  "type": "SEQ",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": ","
+                                    },
+                                    {
+                                      "type": "SYMBOL",
+                                      "name": "type_and_value"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "STRING",
+                        "value": ")"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "landingpad_clause": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "catch"
+            },
+            {
+              "type": "STRING",
+              "value": "filter"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        }
+      ]
+    },
+    "blockaddress": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "blockaddress"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "global_var"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "local_var"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_expr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "constant_cast"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_getelementptr"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_select"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_icmp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_fcmp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_extractelement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_insertelement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_shufflevector"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_extractvalue"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_insertvalue"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_fneg"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_bin_op"
+        }
+      ]
+    },
+    "constant_cast": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "cast_inst"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": "to"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_getelementptr": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "getelementptr"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "inbounds"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "inrange"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "type_and_value"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "inrange"
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "type_and_value"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_select": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "select"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_icmp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "icmp"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "icmp_cond"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_fcmp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "fcmp"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "fast_math"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "fcmp_cond"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_extractelement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "extractelement"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_insertelement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "insertelement"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_shufflevector": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "shufflevector"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_extractvalue": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "extractvalue"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "number"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "number"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_insertvalue": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "insertvalue"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "number"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "number"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_fneg": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "STRING",
+            "value": "fneg"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "fast_math"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "constant_bin_op": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "inst_name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "bin_op_keyword"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "nsw"
+              },
+              {
+                "type": "STRING",
+                "value": "nuw"
+              },
+              {
+                "type": "STRING",
+                "value": "exact"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "fast_math"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "bin_op_keyword": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "atomic_bin_op_keyword"
+        },
+        {
+          "type": "STRING",
+          "value": "mul"
+        },
+        {
+          "type": "STRING",
+          "value": "urem"
+        },
+        {
+          "type": "STRING",
+          "value": "srem"
+        },
+        {
+          "type": "STRING",
+          "value": "shl"
+        },
+        {
+          "type": "STRING",
+          "value": "udiv"
+        },
+        {
+          "type": "STRING",
+          "value": "sdiv"
+        },
+        {
+          "type": "STRING",
+          "value": "lshr"
+        },
+        {
+          "type": "STRING",
+          "value": "ashr"
+        },
+        {
+          "type": "STRING",
+          "value": "fmul"
+        },
+        {
+          "type": "STRING",
+          "value": "fdiv"
+        },
+        {
+          "type": "STRING",
+          "value": "frem"
+        }
+      ]
+    },
+    "atomic_bin_op_keyword": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "xchg"
+        },
+        {
+          "type": "STRING",
+          "value": "add"
+        },
+        {
+          "type": "STRING",
+          "value": "sub"
+        },
+        {
+          "type": "STRING",
+          "value": "and"
+        },
+        {
+          "type": "STRING",
+          "value": "nand"
+        },
+        {
+          "type": "STRING",
+          "value": "or"
+        },
+        {
+          "type": "STRING",
+          "value": "xor"
+        },
+        {
+          "type": "STRING",
+          "value": "max"
+        },
+        {
+          "type": "STRING",
+          "value": "min"
+        },
+        {
+          "type": "STRING",
+          "value": "umax"
+        },
+        {
+          "type": "STRING",
+          "value": "umin"
+        },
+        {
+          "type": "STRING",
+          "value": "fadd"
+        },
+        {
+          "type": "STRING",
+          "value": "fsub"
+        }
+      ]
+    },
+    "icmp_cond": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "eq"
+        },
+        {
+          "type": "STRING",
+          "value": "ne"
+        },
+        {
+          "type": "STRING",
+          "value": "ugt"
+        },
+        {
+          "type": "STRING",
+          "value": "uge"
+        },
+        {
+          "type": "STRING",
+          "value": "ult"
+        },
+        {
+          "type": "STRING",
+          "value": "ule"
+        },
+        {
+          "type": "STRING",
+          "value": "sgt"
+        },
+        {
+          "type": "STRING",
+          "value": "sge"
+        },
+        {
+          "type": "STRING",
+          "value": "slt"
+        },
+        {
+          "type": "STRING",
+          "value": "sle"
+        }
+      ]
+    },
+    "fcmp_cond": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "false"
+        },
+        {
+          "type": "STRING",
+          "value": "oeq"
+        },
+        {
+          "type": "STRING",
+          "value": "ogt"
+        },
+        {
+          "type": "STRING",
+          "value": "oge"
+        },
+        {
+          "type": "STRING",
+          "value": "olt"
+        },
+        {
+          "type": "STRING",
+          "value": "ole"
+        },
+        {
+          "type": "STRING",
+          "value": "one"
+        },
+        {
+          "type": "STRING",
+          "value": "ord"
+        },
+        {
+          "type": "STRING",
+          "value": "ueq"
+        },
+        {
+          "type": "STRING",
+          "value": "ugt"
+        },
+        {
+          "type": "STRING",
+          "value": "uge"
+        },
+        {
+          "type": "STRING",
+          "value": "ult"
+        },
+        {
+          "type": "STRING",
+          "value": "ule"
+        },
+        {
+          "type": "STRING",
+          "value": "une"
+        },
+        {
+          "type": "STRING",
+          "value": "uno"
+        },
+        {
+          "type": "STRING",
+          "value": "true"
+        }
+      ]
+    },
+    "cast_inst": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "bitcast"
+        },
+        {
+          "type": "STRING",
+          "value": "trunc"
+        },
+        {
+          "type": "STRING",
+          "value": "zext"
+        },
+        {
+          "type": "STRING",
+          "value": "sext"
+        },
+        {
+          "type": "STRING",
+          "value": "fptrunc"
+        },
+        {
+          "type": "STRING",
+          "value": "fpext"
+        },
+        {
+          "type": "STRING",
+          "value": "addrspacecast"
+        },
+        {
+          "type": "STRING",
+          "value": "uitofp"
+        },
+        {
+          "type": "STRING",
+          "value": "sitofp"
+        },
+        {
+          "type": "STRING",
+          "value": "fptoui"
+        },
+        {
+          "type": "STRING",
+          "value": "fptosi"
+        },
+        {
+          "type": "STRING",
+          "value": "inttoptr"
+        },
+        {
+          "type": "STRING",
+          "value": "ptrtoint"
+        }
+      ]
+    },
+    "atomic_ordering": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "unordered"
+        },
+        {
+          "type": "STRING",
+          "value": "monotonic"
+        },
+        {
+          "type": "STRING",
+          "value": "acquire"
+        },
+        {
+          "type": "STRING",
+          "value": "release"
+        },
+        {
+          "type": "STRING",
+          "value": "acq_rel"
+        },
+        {
+          "type": "STRING",
+          "value": "seq_cst"
+        }
+      ]
+    },
+    "alignment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "align"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "number"
+        }
+      ]
+    },
+    "_load_store_suffix": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "syncscope"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "atomic_ordering"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "STRING",
+                  "value": "align"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "number"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "syncscope": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "syncscope"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "fast_math": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "nnan"
+        },
+        {
+          "type": "STRING",
+          "value": "ninf"
+        },
+        {
+          "type": "STRING",
+          "value": "nsz"
+        },
+        {
+          "type": "STRING",
+          "value": "arcp"
+        },
+        {
+          "type": "STRING",
+          "value": "contract"
+        },
+        {
+          "type": "STRING",
+          "value": "afn"
+        },
+        {
+          "type": "STRING",
+          "value": "reassoc"
+        },
+        {
+          "type": "STRING",
+          "value": "fast"
+        }
+      ]
+    },
+    "_value_array": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "type_and_value"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "type_and_value"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "_within": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "within"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "none"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "local_var"
+            }
+          ]
+        }
+      ]
+    },
+    "_unwind_label": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "unwind"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "to"
+                },
+                {
+                  "type": "STRING",
+                  "value": "caller"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type_and_value"
+            }
+          ]
+        }
+      ]
+    },
+    "use_list_order": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "uselistorder"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "number"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "number"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "use_list_order_bb": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "uselistorder_bb"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "global_var"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "local_var"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "number"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "number"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "module_asm": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "module"
+        },
+        {
+          "type": "STRING",
+          "value": "asm"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm"
+        }
+      ]
+    },
+    "inline_asm": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "asm"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "sideeffect"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "alignstack"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "inteldialect"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "unwind"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asm"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        }
+      ]
+    },
+    "asm": {
+      "type": "SYMBOL",
+      "name": "string"
+    },
+    "global_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "local_var"
         },
         {
           "type": "STRING",
@@ -1325,31 +5592,544 @@
         },
         {
           "type": "STRING",
-          "value": "*"
+          "value": "type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        }
+      ]
+    },
+    "_global_prefix": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "global_var"
         },
         {
           "type": "STRING",
-          "value": ":"
+          "value": "="
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "linkage"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "thread_local"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "unnamed_addr"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "addrspace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "externally_initialized"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "global_global": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_global_prefix"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "global"
+            },
+            {
+              "type": "STRING",
+              "value": "constant"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "attribute"
+              }
+            ]
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "metadata_refs"
+          }
+        }
+      ]
+    },
+    "alias": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_global_prefix"
         },
         {
           "type": "STRING",
-          "value": "~"
+          "value": "alias"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
         },
         {
           "type": "STRING",
-          "value": "^"
+          "value": ","
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "global_var"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "constant_expr"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "attribute"
+              }
+            ]
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "metadata_refs"
+          }
+        }
+      ]
+    },
+    "ifunc": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_global_prefix"
         },
         {
           "type": "STRING",
-          "value": ":"
+          "value": "ifunc"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
         },
         {
           "type": "STRING",
-          "value": "-"
+          "value": ","
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "global_var"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "constant_expr"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "attribute"
+              }
+            ]
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "metadata_refs"
+          }
+        }
+      ]
+    },
+    "thread_local": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "thread_local"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "localdynamic"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "initialexec"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "localexec"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "comdat": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "comdat_ref"
         },
         {
           "type": "STRING",
-          "value": "+"
+          "value": "="
+        },
+        {
+          "type": "STRING",
+          "value": "comdat"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "any"
+            },
+            {
+              "type": "STRING",
+              "value": "exactmatch"
+            },
+            {
+              "type": "STRING",
+              "value": "largest"
+            },
+            {
+              "type": "STRING",
+              "value": "nodeduplicate"
+            },
+            {
+              "type": "STRING",
+              "value": "samesize"
+            }
+          ]
+        }
+      ]
+    },
+    "global_metadata": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "metadata_ref"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "distinct"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "metadata"
+        }
+      ]
+    },
+    "metadata": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "type_and_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "specialized_md"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "metadata_tuple"
+        },
+        {
+          "type": "STRING",
+          "value": "null"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "!"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "string"
+            }
+          ]
+        }
+      ]
+    },
+    "metadata_tuple": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "!"
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "{"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "metadata"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "metadata"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "specialized_md": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "metadata_ref"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "IMMEDIATE_TOKEN",
+                  "content": {
+                    "type": "STRING",
+                    "value": "("
+                  }
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "specialized_md_value"
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "specialized_md_value": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PATTERN",
+          "value": "[-a-zA-Z0-9_.$\\\\]+"
         },
         {
           "type": "STRING",
@@ -1357,36 +6137,286 @@
         },
         {
           "type": "STRING",
-          "value": "..."
+          "value": ":"
         },
         {
           "type": "STRING",
-          "value": "x"
+          "value": ","
+        },
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_primitive_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "var"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_keyword"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "addrspace"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "metadata_tuple"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "specialized_md"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "{"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "specialized_md_value"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "}"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "specialized_md_value"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "specialized_md_value"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "<"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "specialized_md_value"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": ">"
+            }
+          ]
         }
       ]
     },
-    "bracket": {
+    "summary_entry": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "summary_ref"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "PATTERN",
+            "value": "[-a-zA-Z0-9_.$\\\\]+"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "summary_value"
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "number"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "string"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "summary_ref"
+            }
+          ]
+        }
+      ]
+    },
+    "summary_value": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "("
+          "type": "PATTERN",
+          "value": "[-a-zA-Z0-9_.$\\\\]+"
         },
         {
           "type": "STRING",
-          "value": ")"
+          "value": ":"
         },
         {
           "type": "STRING",
-          "value": "["
+          "value": ","
+        },
+        {
+          "type": "SYMBOL",
+          "name": "attribute_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "summary_ref"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "linkage_aux"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "summary_value"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "summary_value"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        }
+      ]
+    },
+    "unnamed_attr_grp": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "attributes"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "attr_ref"
         },
         {
           "type": "STRING",
-          "value": "]"
+          "value": "="
         },
         {
           "type": "STRING",
           "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "attribute"
+          }
         },
         {
           "type": "STRING",
@@ -1398,10 +6428,45 @@
   "extras": [
     {
       "type": "PATTERN",
-      "value": "\\s"
+      "value": "\\s+"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "comment"
     }
   ],
-  "conflicts": [],
+  "conflicts": [
+    [
+      "type_and_value"
+    ],
+    [
+      "instruction_alloca"
+    ],
+    [
+      "instruction_getelementptr"
+    ],
+    [
+      "_load_store_suffix"
+    ],
+    [
+      "instruction_extractvalue"
+    ],
+    [
+      "instruction_insertvalue"
+    ],
+    [
+      "instruction_phi"
+    ],
+    [
+      "instruction_cmpxchg"
+    ],
+    [
+      "instruction_atomicrmw"
+    ],
+    [
+      "instruction_br"
+    ]
+  ],
   "precedences": [],
   "externals": [],
   "inline": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,36 +1,83 @@
 [
   {
-    "type": "boolean",
+    "type": "addrspace",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "number",
+          "named": true
+        }
+      ]
+    }
   },
   {
-    "type": "bracket",
+    "type": "alias",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "addrspace",
+          "named": true
+        },
+        {
+          "type": "attribute",
+          "named": true
+        },
+        {
+          "type": "constant_expr",
+          "named": true
+        },
+        {
+          "type": "global_var",
+          "named": true
+        },
+        {
+          "type": "linkage",
+          "named": true
+        },
+        {
+          "type": "metadata_refs",
+          "named": true
+        },
+        {
+          "type": "thread_local",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unnamed_addr",
+          "named": true
+        }
+      ]
+    }
   },
   {
-    "type": "constant",
+    "type": "alignment",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "number",
+          "named": true
+        }
+      ]
+    }
   },
   {
-    "type": "float",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "identifier",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "keyword",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "module",
+    "type": "argument",
     "named": true,
     "fields": {},
     "children": {
@@ -38,51 +85,79 @@
       "required": false,
       "types": [
         {
-          "type": "boolean",
+          "type": "metadata",
           "named": true
         },
         {
-          "type": "bracket",
+          "type": "param_or_return_attrs",
           "named": true
         },
         {
-          "type": "comment",
+          "type": "type",
           "named": true
         },
         {
-          "type": "constant",
+          "type": "value",
           "named": true
-        },
+        }
+      ]
+    }
+  },
+  {
+    "type": "argument_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
         {
-          "type": "float",
+          "type": "argument",
           "named": true
-        },
+        }
+      ]
+    }
+  },
+  {
+    "type": "array_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
         {
-          "type": "identifier",
+          "type": "array_vector_body",
           "named": true
-        },
+        }
+      ]
+    }
+  },
+  {
+    "type": "array_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
         {
-          "type": "keyword",
+          "type": "type_and_value",
           "named": true
-        },
-        {
-          "type": "label",
-          "named": true
-        },
+        }
+      ]
+    }
+  },
+  {
+    "type": "array_vector_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
         {
           "type": "number",
-          "named": true
-        },
-        {
-          "type": "statement",
-          "named": true
-        },
-        {
-          "type": "string",
-          "named": true
-        },
-        {
-          "type": "symbol",
           "named": true
         },
         {
@@ -93,17 +168,3059 @@
     }
   },
   {
-    "type": "statement",
+    "type": "asm",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "atomic_bin_op_keyword",
     "named": true,
     "fields": {}
   },
   {
-    "type": "symbol",
+    "type": "atomic_ordering",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "attribute",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "alignment",
+          "named": true
+        },
+        {
+          "type": "attr_ref",
+          "named": true
+        },
+        {
+          "type": "attribute_name",
+          "named": true
+        },
+        {
+          "type": "comdat_ref",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "attribute_name",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "bin_op_keyword",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "atomic_bin_op_keyword",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "blockaddress",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "global_var",
+          "named": true
+        },
+        {
+          "type": "local_var",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "calling_conv",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "cast_inst",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "comdat",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "comdat_ref",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_bin_op",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "bin_op_keyword",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "fast_math",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_cast",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "cast_inst",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_expr",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "constant_bin_op",
+          "named": true
+        },
+        {
+          "type": "constant_cast",
+          "named": true
+        },
+        {
+          "type": "constant_extractelement",
+          "named": true
+        },
+        {
+          "type": "constant_extractvalue",
+          "named": true
+        },
+        {
+          "type": "constant_fcmp",
+          "named": true
+        },
+        {
+          "type": "constant_fneg",
+          "named": true
+        },
+        {
+          "type": "constant_getelementptr",
+          "named": true
+        },
+        {
+          "type": "constant_icmp",
+          "named": true
+        },
+        {
+          "type": "constant_insertelement",
+          "named": true
+        },
+        {
+          "type": "constant_insertvalue",
+          "named": true
+        },
+        {
+          "type": "constant_select",
+          "named": true
+        },
+        {
+          "type": "constant_shufflevector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_extractelement",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "extractelement",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_extractvalue",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "extractvalue",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_fcmp",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "fcmp",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "fast_math",
+          "named": true
+        },
+        {
+          "type": "fcmp_cond",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_fneg",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "fneg",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "fast_math",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_getelementptr",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "getelementptr",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_icmp",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "icmp",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "icmp_cond",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_insertelement",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "insertelement",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_insertvalue",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "insertvalue",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_select",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "select",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_shufflevector",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "shufflevector",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "data_layout",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "declare",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "function_header",
+          "named": true
+        },
+        {
+          "type": "metadata_attachment",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "define",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "function_body",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "function_header",
+          "named": true
+        },
+        {
+          "type": "metadata_attachment",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "dll_storage_class",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "dso_local",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "fast_math",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "fcmp_cond",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "function_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "instruction",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "use_list_order",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_header",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "argument_list",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "global_var",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "addrspace",
+          "named": true
+        },
+        {
+          "type": "attribute",
+          "named": true
+        },
+        {
+          "type": "calling_conv",
+          "named": true
+        },
+        {
+          "type": "linkage",
+          "named": true
+        },
+        {
+          "type": "param_or_return_attrs",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unnamed_addr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "global_global",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "addrspace",
+          "named": true
+        },
+        {
+          "type": "attribute",
+          "named": true
+        },
+        {
+          "type": "global_var",
+          "named": true
+        },
+        {
+          "type": "linkage",
+          "named": true
+        },
+        {
+          "type": "metadata_refs",
+          "named": true
+        },
+        {
+          "type": "thread_local",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        },
+        {
+          "type": "unnamed_addr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "global_metadata",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "metadata",
+          "named": true
+        },
+        {
+          "type": "metadata_ref",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "global_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "local_var",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "icmp_cond",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "ifunc",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "addrspace",
+          "named": true
+        },
+        {
+          "type": "attribute",
+          "named": true
+        },
+        {
+          "type": "constant_expr",
+          "named": true
+        },
+        {
+          "type": "global_var",
+          "named": true
+        },
+        {
+          "type": "linkage",
+          "named": true
+        },
+        {
+          "type": "metadata_refs",
+          "named": true
+        },
+        {
+          "type": "thread_local",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "unnamed_addr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "inline_asm",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "asm",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "instruction_alloca",
+          "named": true
+        },
+        {
+          "type": "instruction_atomicrmw",
+          "named": true
+        },
+        {
+          "type": "instruction_bin_op",
+          "named": true
+        },
+        {
+          "type": "instruction_br",
+          "named": true
+        },
+        {
+          "type": "instruction_call",
+          "named": true
+        },
+        {
+          "type": "instruction_callbr",
+          "named": true
+        },
+        {
+          "type": "instruction_cast",
+          "named": true
+        },
+        {
+          "type": "instruction_catchpad",
+          "named": true
+        },
+        {
+          "type": "instruction_catchret",
+          "named": true
+        },
+        {
+          "type": "instruction_catchswitch",
+          "named": true
+        },
+        {
+          "type": "instruction_cleanuppad",
+          "named": true
+        },
+        {
+          "type": "instruction_cleanupret",
+          "named": true
+        },
+        {
+          "type": "instruction_cmpxchg",
+          "named": true
+        },
+        {
+          "type": "instruction_extractelement",
+          "named": true
+        },
+        {
+          "type": "instruction_extractvalue",
+          "named": true
+        },
+        {
+          "type": "instruction_fcmp",
+          "named": true
+        },
+        {
+          "type": "instruction_fence",
+          "named": true
+        },
+        {
+          "type": "instruction_fneg",
+          "named": true
+        },
+        {
+          "type": "instruction_freeze",
+          "named": true
+        },
+        {
+          "type": "instruction_getelementptr",
+          "named": true
+        },
+        {
+          "type": "instruction_icmp",
+          "named": true
+        },
+        {
+          "type": "instruction_indirectbr",
+          "named": true
+        },
+        {
+          "type": "instruction_insertelement",
+          "named": true
+        },
+        {
+          "type": "instruction_insertvalue",
+          "named": true
+        },
+        {
+          "type": "instruction_invoke",
+          "named": true
+        },
+        {
+          "type": "instruction_landingpad",
+          "named": true
+        },
+        {
+          "type": "instruction_load",
+          "named": true
+        },
+        {
+          "type": "instruction_phi",
+          "named": true
+        },
+        {
+          "type": "instruction_resume",
+          "named": true
+        },
+        {
+          "type": "instruction_ret",
+          "named": true
+        },
+        {
+          "type": "instruction_select",
+          "named": true
+        },
+        {
+          "type": "instruction_shufflevector",
+          "named": true
+        },
+        {
+          "type": "instruction_store",
+          "named": true
+        },
+        {
+          "type": "instruction_switch",
+          "named": true
+        },
+        {
+          "type": "instruction_unreachable",
+          "named": true
+        },
+        {
+          "type": "instruction_va_arg",
+          "named": true
+        },
+        {
+          "type": "local_var",
+          "named": true
+        },
+        {
+          "type": "metadata_refs",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_alloca",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "alloca",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "addrspace",
+          "named": true
+        },
+        {
+          "type": "alignment",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_atomicrmw",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "atomicrmw",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alignment",
+          "named": true
+        },
+        {
+          "type": "atomic_bin_op_keyword",
+          "named": true
+        },
+        {
+          "type": "atomic_ordering",
+          "named": true
+        },
+        {
+          "type": "syncscope",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_bin_op",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "bin_op_keyword",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "fast_math",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        },
+        {
+          "type": "value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_br",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "br",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_call",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "argument_list",
+            "named": true
+          }
+        ]
+      },
+      "callee": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "inline_asm",
+            "named": true
+          },
+          {
+            "type": "value",
+            "named": true
+          }
+        ]
+      },
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "call",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "addrspace",
+          "named": true
+        },
+        {
+          "type": "attribute",
+          "named": true
+        },
+        {
+          "type": "calling_conv",
+          "named": true
+        },
+        {
+          "type": "fast_math",
+          "named": true
+        },
+        {
+          "type": "operand_bundles",
+          "named": true
+        },
+        {
+          "type": "param_or_return_attrs",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_callbr",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "argument_list",
+            "named": true
+          }
+        ]
+      },
+      "callee": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "inline_asm",
+            "named": true
+          },
+          {
+            "type": "value",
+            "named": true
+          }
+        ]
+      },
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "callbr",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "addrspace",
+          "named": true
+        },
+        {
+          "type": "attribute",
+          "named": true
+        },
+        {
+          "type": "calling_conv",
+          "named": true
+        },
+        {
+          "type": "operand_bundles",
+          "named": true
+        },
+        {
+          "type": "param_or_return_attrs",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_cast",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "cast_inst",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_catchpad",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "catchpad",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "local_var",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_catchret",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "catchret",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "local_var",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_catchswitch",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "catchswitch",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "local_var",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_cleanuppad",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "cleanuppad",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "local_var",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_cleanupret",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "cleanupret",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "local_var",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_cmpxchg",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "cmpxchg",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "alignment",
+          "named": true
+        },
+        {
+          "type": "atomic_ordering",
+          "named": true
+        },
+        {
+          "type": "syncscope",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_extractelement",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "extractelement",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_extractvalue",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "extractvalue",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_fcmp",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "fcmp",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "fast_math",
+          "named": true
+        },
+        {
+          "type": "fcmp_cond",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        },
+        {
+          "type": "value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_fence",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "fence",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "atomic_ordering",
+          "named": true
+        },
+        {
+          "type": "syncscope",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_fneg",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "fneg",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "fast_math",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_freeze",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "freeze",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_getelementptr",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "getelementptr",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_icmp",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "icmp",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "icmp_cond",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        },
+        {
+          "type": "value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_indirectbr",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "indirectbr",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_insertelement",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "insertelement",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_insertvalue",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "insertvalue",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_invoke",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "argument_list",
+            "named": true
+          }
+        ]
+      },
+      "callee": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "inline_asm",
+            "named": true
+          },
+          {
+            "type": "value",
+            "named": true
+          }
+        ]
+      },
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "invoke",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "addrspace",
+          "named": true
+        },
+        {
+          "type": "attribute",
+          "named": true
+        },
+        {
+          "type": "calling_conv",
+          "named": true
+        },
+        {
+          "type": "operand_bundles",
+          "named": true
+        },
+        {
+          "type": "param_or_return_attrs",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_landingpad",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "landingpad",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "landingpad_clause",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_load",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "load",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "atomic_ordering",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "syncscope",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_phi",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "phi",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "fast_math",
+          "named": true
+        },
+        {
+          "type": "local_var",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_resume",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "resume",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_ret",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "ret",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_select",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "select",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "fast_math",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_shufflevector",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "shufflevector",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_store",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "store",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "atomic_ordering",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "syncscope",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_switch",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "switch",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instruction_unreachable",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "unreachable",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "instruction_va_arg",
+    "named": true,
+    "fields": {
+      "inst_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "va_arg",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "landingpad_clause",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "linkage",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "dll_storage_class",
+          "named": true
+        },
+        {
+          "type": "dso_local",
+          "named": true
+        },
+        {
+          "type": "linkage_aux",
+          "named": true
+        },
+        {
+          "type": "visibility",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "linkage_aux",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "metadata",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "metadata_tuple",
+          "named": true
+        },
+        {
+          "type": "specialized_md",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "metadata_attachment",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "metadata",
+          "named": true
+        },
+        {
+          "type": "metadata_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "metadata_name",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "metadata_ref",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "metadata_refs",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "metadata",
+          "named": true
+        },
+        {
+          "type": "metadata_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "metadata_tuple",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "metadata",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "module",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "alias",
+          "named": true
+        },
+        {
+          "type": "comdat",
+          "named": true
+        },
+        {
+          "type": "declare",
+          "named": true
+        },
+        {
+          "type": "define",
+          "named": true
+        },
+        {
+          "type": "global_global",
+          "named": true
+        },
+        {
+          "type": "global_metadata",
+          "named": true
+        },
+        {
+          "type": "global_type",
+          "named": true
+        },
+        {
+          "type": "ifunc",
+          "named": true
+        },
+        {
+          "type": "module_asm",
+          "named": true
+        },
+        {
+          "type": "source_file_name",
+          "named": true
+        },
+        {
+          "type": "summary_entry",
+          "named": true
+        },
+        {
+          "type": "target_definition",
+          "named": true
+        },
+        {
+          "type": "unnamed_attr_grp",
+          "named": true
+        },
+        {
+          "type": "use_list_order",
+          "named": true
+        },
+        {
+          "type": "use_list_order_bb",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "module_asm",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "asm",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "number",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "operand_bundles",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "packed_struct_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "struct_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "packed_struct_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "param_or_return_attrs",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "attribute_name",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "source_file_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "specialized_md",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "metadata_ref",
+          "named": true
+        },
+        {
+          "type": "specialized_md_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "specialized_md_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "addrspace",
+          "named": true
+        },
+        {
+          "type": "cstring",
+          "named": true
+        },
+        {
+          "type": "float",
+          "named": true
+        },
+        {
+          "type": "metadata_tuple",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "specialized_md",
+          "named": true
+        },
+        {
+          "type": "specialized_md_value",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "type_keyword",
+          "named": true
+        },
+        {
+          "type": "var",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "struct_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "struct_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "struct_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "struct_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "summary_entry",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "summary_ref",
+          "named": true
+        },
+        {
+          "type": "summary_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "summary_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "attribute_name",
+          "named": true
+        },
+        {
+          "type": "linkage_aux",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "summary_ref",
+          "named": true
+        },
+        {
+          "type": "summary_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "syncscope",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "target_definition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "data_layout",
+          "named": true
+        },
+        {
+          "type": "target_triple",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "target_triple",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "thread_local",
     "named": true,
     "fields": {}
   },
   {
     "type": "type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "addrspace",
+          "named": true
+        },
+        {
+          "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "array_type",
+          "named": true
+        },
+        {
+          "type": "local_var",
+          "named": true
+        },
+        {
+          "type": "packed_struct_type",
+          "named": true
+        },
+        {
+          "type": "struct_type",
+          "named": true
+        },
+        {
+          "type": "type_keyword",
+          "named": true
+        },
+        {
+          "type": "vector_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "type_and_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "metadata",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "type_keyword",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "unnamed_addr",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "unnamed_attr_grp",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "attr_ref",
+          "named": true
+        },
+        {
+          "type": "attribute",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "use_list_order",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "use_list_order_bb",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "global_var",
+          "named": true
+        },
+        {
+          "type": "local_var",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "array_value",
+          "named": true
+        },
+        {
+          "type": "blockaddress",
+          "named": true
+        },
+        {
+          "type": "constant_expr",
+          "named": true
+        },
+        {
+          "type": "cstring",
+          "named": true
+        },
+        {
+          "type": "float",
+          "named": true
+        },
+        {
+          "type": "linkage",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "packed_struct_value",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "struct_value",
+          "named": true
+        },
+        {
+          "type": "var",
+          "named": true
+        },
+        {
+          "type": "vector_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "var",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "global_var",
+          "named": true
+        },
+        {
+          "type": "local_var",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "vector_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "array_vector_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "vector_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "type_and_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "visibility",
     "named": true,
     "fields": {}
   },
@@ -124,15 +3241,7 @@
     "named": false
   },
   {
-    "type": "+",
-    "named": false
-  },
-  {
     "type": ",",
-    "named": false
-  },
-  {
-    "type": "-",
     "named": false
   },
   {
@@ -144,7 +3253,19 @@
     "named": false
   },
   {
+    "type": "<",
+    "named": false
+  },
+  {
+    "type": "<{",
+    "named": false
+  },
+  {
     "type": "=",
+    "named": false
+  },
+  {
+    "type": ">",
     "named": false
   },
   {
@@ -153,10 +3274,6 @@
   },
   {
     "type": "]",
-    "named": false
-  },
-  {
-    "type": "^",
     "named": false
   },
   {
@@ -177,6 +3294,10 @@
   },
   {
     "type": "addrspacecast",
+    "named": false
+  },
+  {
+    "type": "afn",
     "named": false
   },
   {
@@ -208,6 +3329,14 @@
     "named": false
   },
   {
+    "type": "any",
+    "named": false
+  },
+  {
+    "type": "anyregcc",
+    "named": false
+  },
+  {
     "type": "appending",
     "named": false
   },
@@ -217,18 +3346,6 @@
   },
   {
     "type": "argmemonly",
-    "named": false
-  },
-  {
-    "type": "arm_aapcs_vfpcc",
-    "named": false
-  },
-  {
-    "type": "arm_aapcscc",
-    "named": false
-  },
-  {
-    "type": "arm_apcscc",
     "named": false
   },
   {
@@ -245,6 +3362,14 @@
   },
   {
     "type": "atomicrmw",
+    "named": false
+  },
+  {
+    "type": "attr_ref",
+    "named": true
+  },
+  {
+    "type": "attributes",
     "named": false
   },
   {
@@ -277,10 +3402,6 @@
   },
   {
     "type": "byval",
-    "named": false
-  },
-  {
-    "type": "c",
     "named": false
   },
   {
@@ -320,6 +3441,10 @@
     "named": false
   },
   {
+    "type": "cfguard_checkcc",
+    "named": false
+  },
+  {
     "type": "cleanup",
     "named": false
   },
@@ -348,6 +3473,10 @@
     "named": false
   },
   {
+    "type": "comdat_ref",
+    "named": true
+  },
+  {
     "type": "comment",
     "named": true
   },
@@ -360,7 +3489,19 @@
     "named": false
   },
   {
+    "type": "contract",
+    "named": false
+  },
+  {
     "type": "convergent",
+    "named": false
+  },
+  {
+    "type": "cstring",
+    "named": true
+  },
+  {
+    "type": "cxx_fast_tlscc",
     "named": false
   },
   {
@@ -380,15 +3521,15 @@
     "named": false
   },
   {
-    "type": "deplibs",
-    "named": false
-  },
-  {
     "type": "dereferenceable",
     "named": false
   },
   {
     "type": "dereferenceable_or_null",
+    "named": false
+  },
+  {
+    "type": "disable_sanitizer_instrumentation",
     "named": false
   },
   {
@@ -412,7 +3553,15 @@
     "named": false
   },
   {
+    "type": "dso_local_equivalent",
+    "named": false
+  },
+  {
     "type": "dso_preemptable",
+    "named": false
+  },
+  {
+    "type": "elementtype",
     "named": false
   },
   {
@@ -424,7 +3573,7 @@
     "named": false
   },
   {
-    "type": "except",
+    "type": "exactmatch",
     "named": false
   },
   {
@@ -481,6 +3630,10 @@
   },
   {
     "type": "float",
+    "named": true
+  },
+  {
+    "type": "float",
     "named": false
   },
   {
@@ -512,10 +3665,6 @@
     "named": false
   },
   {
-    "type": "free",
-    "named": false
-  },
-  {
     "type": "freeze",
     "named": false
   },
@@ -540,19 +3689,19 @@
     "named": false
   },
   {
+    "type": "ghccc",
+    "named": false
+  },
+  {
     "type": "global",
     "named": false
   },
   {
+    "type": "global_var",
+    "named": true
+  },
+  {
     "type": "half",
-    "named": false
-  },
-  {
-    "type": "hhvm_ccc",
-    "named": false
-  },
-  {
-    "type": "hhvmcc",
     "named": false
   },
   {
@@ -565,6 +3714,10 @@
   },
   {
     "type": "icmp",
+    "named": false
+  },
+  {
+    "type": "ifunc",
     "named": false
   },
   {
@@ -588,6 +3741,10 @@
     "named": false
   },
   {
+    "type": "indirect-tls-seg-refs",
+    "named": false
+  },
+  {
     "type": "indirectbr",
     "named": false
   },
@@ -600,6 +3757,10 @@
     "named": false
   },
   {
+    "type": "inrange",
+    "named": false
+  },
+  {
     "type": "inreg",
     "named": false
   },
@@ -609,10 +3770,6 @@
   },
   {
     "type": "insertvalue",
-    "named": false
-  },
-  {
-    "type": "intel_ocl_bicc",
     "named": false
   },
   {
@@ -648,6 +3805,10 @@
     "named": false
   },
   {
+    "type": "largest",
+    "named": false
+  },
+  {
     "type": "linkonce",
     "named": false
   },
@@ -664,6 +3825,10 @@
     "named": false
   },
   {
+    "type": "local_var",
+    "named": true
+  },
+  {
     "type": "localdynamic",
     "named": false
   },
@@ -673,10 +3838,6 @@
   },
   {
     "type": "lshr",
-    "named": false
-  },
-  {
-    "type": "malloc",
     "named": false
   },
   {
@@ -701,10 +3862,6 @@
   },
   {
     "type": "monotonic",
-    "named": false
-  },
-  {
-    "type": "msp430_intrcc",
     "named": false
   },
   {
@@ -744,6 +3901,14 @@
     "named": false
   },
   {
+    "type": "no-jump-tables",
+    "named": false
+  },
+  {
+    "type": "no_cfi",
+    "named": false
+  },
+  {
     "type": "noalias",
     "named": false
   },
@@ -752,15 +3917,15 @@
     "named": false
   },
   {
-    "type": "nocallback",
-    "named": false
-  },
-  {
     "type": "nocapture",
     "named": false
   },
   {
     "type": "nocf_check",
+    "named": false
+  },
+  {
+    "type": "nodeduplicate",
     "named": false
   },
   {
@@ -820,6 +3985,10 @@
     "named": false
   },
   {
+    "type": "notail",
+    "named": false
+  },
+  {
     "type": "noundef",
     "named": false
   },
@@ -842,10 +4011,6 @@
   {
     "type": "null_pointer_is_valid",
     "named": false
-  },
-  {
-    "type": "number",
-    "named": true
   },
   {
     "type": "nuw",
@@ -876,6 +4041,10 @@
     "named": false
   },
   {
+    "type": "opaque",
+    "named": false
+  },
+  {
     "type": "optforfuzzing",
     "named": false
   },
@@ -896,7 +4065,7 @@
     "named": false
   },
   {
-    "type": "pcc_fp128",
+    "type": "partition",
     "named": false
   },
   {
@@ -912,7 +4081,23 @@
     "named": false
   },
   {
+    "type": "ppc_fp128",
+    "named": false
+  },
+  {
     "type": "preallocated",
+    "named": false
+  },
+  {
+    "type": "prefix",
+    "named": false
+  },
+  {
+    "type": "preserve_allcc",
+    "named": false
+  },
+  {
+    "type": "preserve_mostcc",
     "named": false
   },
   {
@@ -920,19 +4105,19 @@
     "named": false
   },
   {
+    "type": "prologue",
+    "named": false
+  },
+  {
     "type": "protected",
     "named": false
   },
   {
+    "type": "ptr",
+    "named": false
+  },
+  {
     "type": "ptrtoint",
-    "named": false
-  },
-  {
-    "type": "ptx_device",
-    "named": false
-  },
-  {
-    "type": "ptx_kernel",
     "named": false
   },
   {
@@ -941,6 +4126,10 @@
   },
   {
     "type": "readonly",
+    "named": false
+  },
+  {
+    "type": "reassoc",
     "named": false
   },
   {
@@ -965,6 +4154,10 @@
   },
   {
     "type": "safestack",
+    "named": false
+  },
+  {
+    "type": "samesize",
     "named": false
   },
   {
@@ -1060,14 +4253,6 @@
     "named": false
   },
   {
-    "type": "spir_func",
-    "named": false
-  },
-  {
-    "type": "spir_kernel",
-    "named": false
-  },
-  {
     "type": "srem",
     "named": false
   },
@@ -1101,6 +4286,14 @@
   },
   {
     "type": "sub",
+    "named": false
+  },
+  {
+    "type": "summary_ref",
+    "named": true
+  },
+  {
+    "type": "swiftasync",
     "named": false
   },
   {
@@ -1148,6 +4341,10 @@
     "named": false
   },
   {
+    "type": "token",
+    "named": false
+  },
+  {
     "type": "triple",
     "named": false
   },
@@ -1157,6 +4354,10 @@
   },
   {
     "type": "trunc",
+    "named": false
+  },
+  {
+    "type": "type",
     "named": false
   },
   {
@@ -1256,6 +4457,10 @@
     "named": false
   },
   {
+    "type": "vscale_range",
+    "named": false
+  },
+  {
     "type": "weak",
     "named": false
   },
@@ -1264,11 +4469,11 @@
     "named": false
   },
   {
-    "type": "willreturn",
+    "type": "webkit_jscc",
     "named": false
   },
   {
-    "type": "win64cc",
+    "type": "willreturn",
     "named": false
   },
   {
@@ -1284,15 +4489,7 @@
     "named": false
   },
   {
-    "type": "x86_64_sysvcc",
-    "named": false
-  },
-  {
     "type": "x86_amx",
-    "named": false
-  },
-  {
-    "type": "x86_fastcallcc",
     "named": false
   },
   {
@@ -1301,14 +4498,6 @@
   },
   {
     "type": "x86_mmx",
-    "named": false
-  },
-  {
-    "type": "x86_stdcallcc",
-    "named": false
-  },
-  {
-    "type": "x86_thiscallcc",
     "named": false
   },
   {
@@ -1344,7 +4533,7 @@
     "named": false
   },
   {
-    "type": "~",
+    "type": "}>",
     "named": false
   }
 ]

--- a/test/corpus/instructions.ll
+++ b/test/corpus/instructions.ll
@@ -1,0 +1,4921 @@
+================================================================================
+ret
+================================================================================
+
+define void @main() {
+  ret i32 5                       ; Return an integer value of 5
+  ret void                        ; Return from a void function
+  ret { i32, i8 } { i32 4, i8 2 } ; Return a struct of values 4 and 2
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment)
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword)))))
+      (comment)
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (type_keyword)))))
+            (value
+              (struct_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))))
+      (comment))))
+
+================================================================================
+br
+================================================================================
+
+define void @main() {
+Test:
+  %cond = icmp eq i32 %a, %b
+  br i1 %cond, label %IfEqual, label %IfUnequal
+IfEqual:
+  ret i32 1
+IfUnequal:
+  ret i32 0
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (label)
+      (instruction
+        (local_var)
+        (instruction_icmp
+          (icmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (value
+            (var
+              (local_var)))))
+      (instruction
+        (instruction_br
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (label)
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (label)
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number))))))))
+
+================================================================================
+switch
+================================================================================
+
+define void @main() {
+  ; Emulate a conditional br instruction
+  %Val = zext i1 %value to i32
+  switch i32 %Val, label %truedest [ i32 0, label %falsedest ]
+  
+  ; Emulate an unconditional br instruction
+  switch i32 0, label %dest [ ]
+  
+  ; Implement a jump table:
+  switch i32 %val, label %otherwise [ i32 0, label %onzero
+                                     i32 1, label %onone
+                                     i32 2, label %ontwo ]
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type
+            (type_keyword))))
+      (instruction
+        (instruction_switch
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (comment)
+      (instruction
+        (instruction_switch
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (comment)
+      (instruction
+        (instruction_switch
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+indirectbr
+================================================================================
+
+define void @main() {
+  indirectbr i8* %Addr, [ label %bb1, label %bb2, label %bb3 ]
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_indirectbr
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+invoke
+================================================================================
+
+define void @main() {
+  %retval = invoke i32 @Test(i32 15) to label %Continue
+              unwind label %TestCleanup              ; i32:retval set
+  %retval = invoke coldcc i32 %Testfnptr(i32 15) to label %Continue
+              unwind label %TestCleanup              ; i32:retval set
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_invoke
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (number))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_invoke
+          (calling_conv)
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var)))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (number))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (comment))))
+
+================================================================================
+callbr
+================================================================================
+
+define void @main() {
+  ; "asm goto" without output constraints.
+  callbr void asm "", "r,X"(i32 %x, i8 *blockaddress(@foo, %indirect))
+              to label %fallthrough [label %indirect]
+  
+  ; "asm goto" with output constraints.
+  %result = callbr i32 asm "", "=r,r,X"(i32 %x, i8 *blockaddress(@foo, %indirect))
+               to label %fallthrough [label %indirect]
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (comment)
+      (instruction
+        (instruction_callbr
+          (type
+            (type_keyword))
+          (inline_asm
+            (asm
+              (string))
+            (string))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (local_var))))
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (blockaddress
+                  (global_var)
+                  (local_var)))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_callbr
+          (type
+            (type_keyword))
+          (inline_asm
+            (asm
+              (string))
+            (string))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (local_var))))
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (blockaddress
+                  (global_var)
+                  (local_var)))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+resume
+================================================================================
+
+define void @main() {
+  resume { i8*, i32 } %exn
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_resume
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+catchswitch
+================================================================================
+
+define void @main() {
+dispatch1:
+  %cs1 = catchswitch within none [label %handler0, label %handler1] unwind to caller
+dispatch2:
+  %cs2 = catchswitch within %parenthandler [label %handler0] unwind label %cleanup
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (label)
+      (instruction
+        (local_var)
+        (instruction_catchswitch
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (label)
+      (instruction
+        (local_var)
+        (instruction_catchswitch
+          (local_var)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+catchret
+================================================================================
+
+define void @main() {
+  catchret from %catch to label %continue
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_catchret
+          (local_var)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+cleanupret
+================================================================================
+
+define void @main() {
+  cleanupret from %cleanup unwind to caller
+  cleanupret from %cleanup unwind label %continue
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_cleanupret
+          (local_var)))
+      (instruction
+        (instruction_cleanupret
+          (local_var)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+fneg
+================================================================================
+
+define void @main() {
+  %result = fneg float %val          ; yields float:result = -%var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_fneg
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (comment))))
+
+================================================================================
+add
+================================================================================
+
+define void @main() {
+  %result = add i32 4, %var          ; yields i32:result = 4 + %var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (var
+              (local_var)))))
+      (comment))))
+
+================================================================================
+fadd
+================================================================================
+
+define void @main() {
+  %result = fadd float 4.0, %var          ; yields float:result = 4.0 + %var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (value
+            (var
+              (local_var)))))
+      (comment))))
+
+================================================================================
+sub
+================================================================================
+
+define void @main() {
+  %result = sub i32 4, %var          ; yields i32:result = 4 - %var
+  %result = sub i32 0, %val          ; yields i32:result = -%var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (var
+              (local_var)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (var
+              (local_var)))))
+      (comment))))
+
+================================================================================
+fsub
+================================================================================
+
+define void @main() {
+  %result = fsub float 4.0, %var           ; yields float:result = 4.0 - %var
+  %result = fsub float -0.0, %val          ; yields float:result = -%var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (value
+            (var
+              (local_var)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (value
+            (var
+              (local_var)))))
+      (comment))))
+
+================================================================================
+mul
+================================================================================
+
+define void @main() {
+  %result = mul i32 4, %var          ; yields i32:result = 4 * %var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (var
+              (local_var)))))
+      (comment))))
+
+================================================================================
+fmul
+================================================================================
+
+define void @main() {
+  %result = fmul float 4.0, %var          ; yields float:result = 4.0 * %var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (value
+            (var
+              (local_var)))))
+      (comment))))
+
+================================================================================
+sdiv
+================================================================================
+
+define void @main() {
+  %result = sdiv i32 4, %var          ; yields i32:result = 4 / %var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (var
+              (local_var)))))
+      (comment))))
+
+================================================================================
+fdiv
+================================================================================
+
+define void @main() {
+  %result = fdiv float 4.0, %var          ; yields float:result = 4.0 / %var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (value
+            (var
+              (local_var)))))
+      (comment))))
+
+================================================================================
+urem
+================================================================================
+
+define void @main() {
+  %result = urem i32 4, %var          ; yields i32:result = 4 % %var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (var
+              (local_var)))))
+      (comment))))
+
+================================================================================
+srem
+================================================================================
+
+define void @main() {
+  %result = srem i32 4, %var          ; yields i32:result = 4 % %var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (var
+              (local_var)))))
+      (comment))))
+
+================================================================================
+frem
+================================================================================
+
+define void @main() {
+  %result = frem float 4.0, %var          ; yields float:result = 4.0 % %var
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (value
+            (var
+              (local_var)))))
+      (comment))))
+
+================================================================================
+shl
+================================================================================
+
+define void @main() {
+  %result = shl i32 4, %var   ; yields i32: 4 << %var
+  %result = shl i32 4, 2      ; yields i32: 16
+  %result = shl i32 1, 10     ; yields i32: 1024
+  %result = shl i32 1, 32     ; undefined
+  %result = shl <2 x i32> < i32 1, i32 1>, < i32 1, i32 2>   ; yields: result=<2 x i32> < i32 2, i32 4>
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (var
+              (local_var)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))
+          (value
+            (vector_value
+              (type_and_value
+                (type
+                  (type_keyword))
+                (value
+                  (number)))
+              (type_and_value
+                (type
+                  (type_keyword))
+                (value
+                  (number)))))))
+      (comment))))
+
+================================================================================
+lshr
+================================================================================
+
+define void @main() {
+  %result = lshr i32 4, 1   ; yields i32:result = 2
+  %result = lshr i32 4, 2   ; yields i32:result = 1
+  %result = lshr i8  4, 3   ; yields i8:result = 0
+  %result = lshr i8 -2, 1   ; yields i8:result = 0x7F
+  %result = lshr i32 1, 32  ; undefined
+  %result = lshr <2 x i32> < i32 -2, i32 4>, < i32 1, i32 2>   ; yields: result=<2 x i32> < i32 0x7FFFFFFF, i32 1>
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))
+          (value
+            (vector_value
+              (type_and_value
+                (type
+                  (type_keyword))
+                (value
+                  (number)))
+              (type_and_value
+                (type
+                  (type_keyword))
+                (value
+                  (number)))))))
+      (comment))))
+
+================================================================================
+ashr
+================================================================================
+
+define void @main() {
+  %result = ashr i32 4, 1   ; yields i32:result = 2
+  %result = ashr i32 4, 2   ; yields i32:result = 1
+  %result = ashr i8  4, 3   ; yields i8:result = 0
+  %result = ashr i8 -2, 1   ; yields i8:result = -1
+  %result = ashr i32 1, 32  ; undefined
+  %result = ashr <2 x i32> < i32 -2, i32 4>, < i32 1, i32 3>   ; yields: result=<2 x i32> < i32 -1, i32 0>
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))
+          (value
+            (vector_value
+              (type_and_value
+                (type
+                  (type_keyword))
+                (value
+                  (number)))
+              (type_and_value
+                (type
+                  (type_keyword))
+                (value
+                  (number)))))))
+      (comment))))
+
+================================================================================
+and
+================================================================================
+
+define void @main() {
+  %result = and i32 4, %var         ; yields i32:result = 4 & %var
+  %result = and i32 15, 40          ; yields i32:result = 8
+  %result = and i32 4, 8            ; yields i32:result = 0
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (var
+              (local_var)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment))))
+
+================================================================================
+or
+================================================================================
+
+define void @main() {
+  %result = or i32 4, %var         ; yields i32:result = 4 | %var
+  %result = or i32 15, 40          ; yields i32:result = 47
+  %result = or i32 4, 8            ; yields i32:result = 12
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (var
+              (local_var)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment))))
+
+================================================================================
+xor
+================================================================================
+
+define void @main() {
+  %result = xor i32 4, %var         ; yields i32:result = 4 ^ %var
+  %result = xor i32 15, 40          ; yields i32:result = 39
+  %result = xor i32 4, 8            ; yields i32:result = 12
+  %result = xor i32 %V, -1          ; yields i32:result = ~%V
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (var
+              (local_var)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (value
+            (number))))
+      (comment))))
+
+================================================================================
+extractelement
+================================================================================
+
+define void @main() {
+  %result = extractelement <4 x i32> %vec, i32 0    ; yields i32
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_extractelement
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment))))
+
+================================================================================
+insertelement
+================================================================================
+
+define void @main() {
+  %result = insertelement <4 x i32> %vec, i32 1, i32 0    ; yields <4 x i32>
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_insertelement
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment))))
+
+================================================================================
+shufflevector
+================================================================================
+
+define void @main() {
+  %result = shufflevector <4 x i32> %v1, <4 x i32> %v2,
+                          <4 x i32> <i32 0, i32 4, i32 1, i32 5>  ; yields <4 x i32>
+  %result = shufflevector <4 x i32> %v1, <4 x i32> undef,
+                          <4 x i32> <i32 0, i32 1, i32 2, i32 3>  ; yields <4 x i32> - Identity shuffle.
+  %result = shufflevector <8 x i32> %v1, <8 x i32> undef,
+                          <4 x i32> <i32 0, i32 1, i32 2, i32 3>  ; yields <4 x i32>
+  %result = shufflevector <4 x i32> %v1, <4 x i32> %v2,
+                          <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7 >  ; yields <8 x i32>
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_shufflevector
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_shufflevector
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_shufflevector
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_shufflevector
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))))
+      (comment))))
+
+================================================================================
+extractvalue
+================================================================================
+
+define void @main() {
+  %result = extractvalue {i32, float} %agg, 0    ; yields i32
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_extractvalue
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (number)))
+      (comment))))
+
+================================================================================
+insertvalue
+================================================================================
+
+define void @main() {
+  %agg1 = insertvalue {i32, float} undef, i32 1, 0              ; yields {i32 1, float undef}
+  %agg2 = insertvalue {i32, float} %agg1, float %val, 1         ; yields {i32 1, float %val}
+  %agg3 = insertvalue {i32, {float}} undef, float %val, 1, 0    ; yields {i32 undef, {float %val}}
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_insertvalue
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (type_keyword)))))
+            (value))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (number)))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_insertvalue
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (number)))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_insertvalue
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (struct_type
+                      (struct_body
+                        (type
+                          (type_keyword))))))))
+            (value))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (number)
+          (number)))
+      (comment))))
+
+================================================================================
+alloca
+================================================================================
+
+define void @main() {
+  %ptr = alloca i32                             ; yields i32*:ptr
+  %ptr = alloca i32, i32 4                      ; yields i32*:ptr
+  %ptr = alloca i32, i32 4, align 1024          ; yields i32*:ptr
+  %ptr = alloca i32, align 1024                 ; yields i32*:ptr
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_alloca
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_alloca
+          (type
+            (type_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_alloca
+          (type
+            (type_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (alignment
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_alloca
+          (type
+            (type_keyword))
+          (alignment
+            (number))))
+      (comment))))
+
+================================================================================
+load
+================================================================================
+
+define void @main() {
+  %ptr = alloca i32                               ; yields i32*:ptr
+  store i32 3, i32* %ptr                          ; yields void
+  %val = load i32, i32* %ptr                      ; yields i32:val = i32 3
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_alloca
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (instruction_store
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_load
+          (type
+            (type_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (comment))))
+
+================================================================================
+store
+================================================================================
+
+define void @main() {
+  %ptr = alloca i32                               ; yields i32*:ptr
+  store i32 3, i32* %ptr                          ; yields void
+  %val = load i32, i32* %ptr                      ; yields i32:val = i32 3
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_alloca
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (instruction_store
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_load
+          (type
+            (type_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (comment))))
+
+================================================================================
+fence
+================================================================================
+
+define void @main() {
+  fence acquire                                        ; yields void
+  fence syncscope("singlethread") seq_cst              ; yields void
+  fence syncscope("agent") seq_cst                     ; yields void
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_fence
+          (atomic_ordering)))
+      (comment)
+      (instruction
+        (instruction_fence
+          (syncscope
+            (string))
+          (atomic_ordering)))
+      (comment)
+      (instruction
+        (instruction_fence
+          (syncscope
+            (string))
+          (atomic_ordering)))
+      (comment))))
+
+================================================================================
+cmpxchg
+================================================================================
+
+define void @main() {
+entry:
+  %orig = load atomic i32, i32* %ptr unordered, align 4                      ; yields i32
+  br label %loop
+
+loop:
+  %cmp = phi i32 [ %orig, %entry ], [%value_loaded, %loop]
+  %squared = mul i32 %cmp, %cmp
+  %val_success = cmpxchg i32* %ptr, i32 %cmp, i32 %squared acq_rel monotonic ; yields  { i32, i1 }
+  %value_loaded = extractvalue { i32, i1 } %val_success, 0
+  %success = extractvalue { i32, i1 } %val_success, 1
+  br i1 %success, label %done, label %loop
+
+done:
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (label)
+      (instruction
+        (local_var)
+        (instruction_load
+          (type
+            (type_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (atomic_ordering)
+          (number)))
+      (comment)
+      (instruction
+        (instruction_br
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (label)
+      (instruction
+        (local_var)
+        (instruction_phi
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var)))
+          (local_var)
+          (value
+            (var
+              (local_var)))
+          (local_var)))
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (value
+            (var
+              (local_var)))))
+      (instruction
+        (local_var)
+        (instruction_cmpxchg
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (atomic_ordering)
+          (atomic_ordering)))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_extractvalue
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (number)))
+      (instruction
+        (local_var)
+        (instruction_extractvalue
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (number)))
+      (instruction
+        (instruction_br
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (label))))
+
+================================================================================
+atomicrmw
+================================================================================
+
+define void @main() {
+  %old = atomicrmw add i32* %ptr, i32 1 acquire                        ; yields i32
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_atomicrmw
+          (atomic_bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (atomic_ordering)))
+      (comment))))
+
+================================================================================
+getelementptr
+================================================================================
+
+%struct.RT = type { i8, [10 x [20 x i32]], i8 }
+%struct.ST = type { i32, double, %struct.RT }
+
+define i32* @foo(%struct.ST* %s) nounwind uwtable readnone optsize ssp {
+entry:
+  %arrayidx = getelementptr inbounds %struct.ST, %struct.ST* %s, i64 1, i32 2, i32 1, i64 5, i64 13
+  ret i32* %arrayidx
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (global_type
+    (local_var)
+    (type
+      (struct_type
+        (struct_body
+          (type
+            (type_keyword))
+          (type
+            (array_type
+              (array_vector_body
+                (number)
+                (type
+                  (array_type
+                    (array_vector_body
+                      (number)
+                      (type
+                        (type_keyword))))))))
+          (type
+            (type_keyword))))))
+  (global_type
+    (local_var)
+    (type
+      (struct_type
+        (struct_body
+          (type
+            (type_keyword))
+          (type
+            (type_keyword))
+          (type
+            (local_var))))))
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (local_var))
+          (value
+            (var
+              (local_var)))))
+      (attribute
+        (attribute_name))
+      (attribute
+        (attribute_name))
+      (attribute
+        (attribute_name))
+      (attribute
+        (attribute_name))
+      (attribute
+        (attribute_name)))
+    (function_body
+      (label)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (local_var)))
+          (type_and_value
+            (type
+              (local_var))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+getelementptr 2
+================================================================================
+
+define i32* @foo(%struct.ST* %s) {
+  %t1 = getelementptr %struct.ST, %struct.ST* %s, i32 1                        ; yields %struct.ST*:%t1
+  %t2 = getelementptr %struct.ST, %struct.ST* %t1, i32 0, i32 2                ; yields %struct.RT*:%t2
+  %t3 = getelementptr %struct.RT, %struct.RT* %t2, i32 0, i32 1                ; yields [10 x [20 x i32]]*:%t3
+  %t4 = getelementptr [10 x [20 x i32]], [10 x [20 x i32]]* %t3, i32 0, i32 5  ; yields [20 x i32]*:%t4
+  %t5 = getelementptr [20 x i32], [20 x i32]* %t4, i32 0, i32 13               ; yields i32*:%t5
+  ret i32* %t5
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (local_var))
+          (value
+            (var
+              (local_var))))))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (local_var)))
+          (type_and_value
+            (type
+              (local_var))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (local_var)))
+          (type_and_value
+            (type
+              (local_var))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (local_var)))
+          (type_and_value
+            (type
+              (local_var))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (array_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (array_type
+                      (array_vector_body
+                        (number)
+                        (type
+                          (type_keyword)))))))))
+          (type_and_value
+            (type
+              (array_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (array_type
+                      (array_vector_body
+                        (number)
+                        (type
+                          (type_keyword))))))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (array_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword))))))
+          (type_and_value
+            (type
+              (array_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment)
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+getelementptr 3
+================================================================================
+
+define void @main() {
+  ; yields [12 x i8]*:aptr
+  %aptr = getelementptr {i32, [12 x i8]}, {i32, [12 x i8]}* %saptr, i64 0, i32 1
+  ; yields i8*:vptr
+  %vptr = getelementptr {i32, <2 x i8>}, {i32, <2 x i8>}* %svptr, i64 0, i32 1, i32 1
+  ; yields i8*:eptr
+  %eptr = getelementptr [12 x i8], [12 x i8]* %aptr, i64 0, i32 1
+  ; yields i32*:iptr
+  %iptr = getelementptr [10 x i32], [10 x i32]* @arr, i16 0, i16 0
+  
+  ; All arguments are vectors:
+  ;   A[i] = ptrs[i] + offsets[i]*sizeof(i8)
+  %A = getelementptr i8, <4 x i8*> %ptrs, <4 x i64> %offsets
+  
+  ; Add the same scalar offset to each pointer of a vector:
+  ;   A[i] = ptrs[i] + offset*sizeof(i8)
+  %A = getelementptr i8, <4 x i8*> %ptrs, i64 %offset
+  
+  ; Add distinct offsets to the same pointer:
+  ;   A[i] = ptr + offsets[i]*sizeof(i8)
+  %A = getelementptr i8, i8* %ptr, <4 x i64> %offsets
+  
+  ; In all cases described above the type of the result is <4 x i8*>
+  
+  getelementptr  %struct.ST, <4 x %struct.ST*> %s, <4 x i64> %ind1,
+    <4 x i32> <i32 2, i32 2, i32 2, i32 2>,
+    <4 x i32> <i32 1, i32 1, i32 1, i32 1>,
+    <4 x i32> %ind4,
+    <4 x i64> <i64 13, i64 13, i64 13, i64 13>
+  
+  getelementptr  %struct.ST, <4 x %struct.ST*> %s, <4 x i64> %ind1,
+    i32 2, i32 1, <4 x i32> %ind4, i64 13
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (array_type
+                      (array_vector_body
+                        (number)
+                        (type
+                          (type_keyword)))))))))
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (array_type
+                      (array_vector_body
+                        (number)
+                        (type
+                          (type_keyword))))))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (vector_type
+                      (array_vector_body
+                        (number)
+                        (type
+                          (type_keyword)))))))))
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (vector_type
+                      (array_vector_body
+                        (number)
+                        (type
+                          (type_keyword))))))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (array_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword))))))
+          (type_and_value
+            (type
+              (array_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (array_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword))))))
+          (type_and_value
+            (type
+              (array_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (global_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment)
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (type_keyword)))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))))
+      (comment)
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (type_keyword)))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (comment)
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (type_keyword)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))))
+      (comment)
+      (instruction
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (local_var)))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (local_var)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))))
+      (instruction
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (local_var)))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (local_var)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number))))))))
+
+================================================================================
+getelementptr 4
+================================================================================
+
+define void @main() {
+  ; get pointers for 8 elements from array B
+  %ptrs = getelementptr double, double* %B, <8 x i32> %C
+  ; load 8 elements from array B into A
+  %A = call <8 x double> @llvm.masked.gather.v8f64.v8p0f64(<8 x double*> %ptrs,
+       i32 8, <8 x i1> %mask, <8 x double> %passthru)
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_getelementptr
+          (type_and_value
+            (type
+              (type_keyword)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_call
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (type
+                (vector_type
+                  (array_vector_body
+                    (number)
+                    (type
+                      (type_keyword)))))
+              (value
+                (var
+                  (local_var))))
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (number)))
+            (argument
+              (type
+                (vector_type
+                  (array_vector_body
+                    (number)
+                    (type
+                      (type_keyword)))))
+              (value
+                (var
+                  (local_var))))
+            (argument
+              (type
+                (vector_type
+                  (array_vector_body
+                    (number)
+                    (type
+                      (type_keyword)))))
+              (value
+                (var
+                  (local_var))))))))))
+
+================================================================================
+trunc
+================================================================================
+
+define void @main() {
+  %X = trunc i32 257 to i8                        ; yields i8:1
+  %Y = trunc i32 123 to i1                        ; yields i1:true
+  %Z = trunc i32 122 to i1                        ; yields i1:false
+  %W = trunc <2 x i16> <i16 8, i16 7> to <2 x i8> ; yields <i8 8, i8 7>
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))))
+      (comment))))
+
+================================================================================
+zext
+================================================================================
+
+define void @main() {
+  %X = zext i32 257 to i64              ; yields i64:257
+  %Y = zext i1 true to i32              ; yields i32:1
+  %Z = zext <2 x i16> <i16 8, i16 7> to <2 x i32> ; yields <i32 8, i32 7>
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))))
+      (comment))))
+
+================================================================================
+sext
+================================================================================
+
+define void @main() {
+  %X = sext i8  -1 to i16              ; yields i16   :65535
+  %Y = sext i1 true to i32             ; yields i32:-1
+  %Z = sext <2 x i16> <i16 8, i16 7> to <2 x i32> ; yields <i32 8, i32 7>
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))))
+      (comment))))
+
+================================================================================
+fptrunc
+================================================================================
+
+define void @main() {
+  %X = fptrunc double 16777217.0 to float    ; yields float:16777216.0
+  %Y = fptrunc double 1.0E+300 to half       ; yields half:+infinity
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (type
+            (type_keyword))))
+      (comment))))
+
+================================================================================
+fpext
+================================================================================
+
+define void @main() {
+  %X = fpext float 3.125 to double         ; yields double:3.125000e+00
+  %Y = fpext double %X to fp128            ; yields fp128:0xL00000000000000004000900000000000
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type
+            (type_keyword))))
+      (comment))))
+
+================================================================================
+fptoui
+================================================================================
+
+define void @main() {
+  %X = fptoui double 123.0 to i32      ; yields i32:123
+  %Y = fptoui float 1.0E+300 to i1     ; yields undefined:1
+  %Z = fptoui float 1.04E+17 to i8     ; yields undefined:1
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (type
+            (type_keyword))))
+      (comment))))
+
+================================================================================
+fptosi
+================================================================================
+
+define void @main() {
+  %X = fptosi double -123.0 to i32      ; yields i32:-123
+  %Y = fptosi float 1.0E-247 to i1      ; yields undefined:1
+  %Z = fptosi float 1.04E+17 to i8      ; yields undefined:1
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (type
+            (type_keyword))))
+      (comment))))
+
+================================================================================
+uitofp
+================================================================================
+
+define void @main() {
+  %X = uitofp i32 257 to float         ; yields float:257.0
+  %Y = uitofp i8 -1 to double          ; yields double:255.0
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment))))
+
+================================================================================
+sitofp
+================================================================================
+
+define void @main() {
+  %X = sitofp i32 257 to float         ; yields float:257.0
+  %Y = sitofp i8 -1 to double          ; yields double:-1.0
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment))))
+
+================================================================================
+ptrtoint
+================================================================================
+
+define void @main() {
+  %X = ptrtoint i32* %P to i8                         ; yields truncation on 32-bit architecture
+  %Y = ptrtoint i32* %P to i64                        ; yields zero extension on 32-bit architecture
+  %Z = ptrtoint <4 x i32*> %P to <4 x i64>; yields vector zero extension for a vector of addresses on 32-bit architecture
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))))
+      (comment))))
+
+================================================================================
+inttoptr
+================================================================================
+
+define void @main() {
+  %X = inttoptr i32 255 to i32*          ; yields zero extension on 64-bit architecture
+  %Y = inttoptr i32 255 to i32*          ; yields no-op on 32-bit architecture
+  %Z = inttoptr i64 0 to i32*            ; yields truncation on 32-bit architecture
+  %Z = inttoptr <4 x i32> %G to <4 x i8*>; yields truncation of vector G to four pointers
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))))
+      (comment))))
+
+================================================================================
+bitcast
+================================================================================
+
+define void @main() {
+  %X = bitcast i8 255 to i8          ; yields i8 :-1
+  %Y = bitcast i32* %x to i32*      ; yields sint*:%x
+  %Z = bitcast <2 x i32> %V to i64;  ; yields i64: %V (depends on endianess)
+  %Z = bitcast <2 x i32*> %V to <2 x i64*> ; yields <2 x i64*>
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type
+            (type_keyword))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))))
+      (comment))))
+
+================================================================================
+addrspacecast
+================================================================================
+
+define void @main() {
+  %X = addrspacecast i32* %x to i32 addrspace(1)*    ; yields i32 addrspace(1)*:%x
+  %Y = addrspacecast i32 addrspace(1)* %y to i64 addrspace(2)*    ; yields i64 addrspace(2)*:%y
+  %Z = addrspacecast <4 x i32*> %z to <4 x float addrspace(3)*>   ; yields <4 x float addrspace(3)*>:%z
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type
+            (type_keyword)
+            (addrspace
+              (number)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword)
+              (addrspace
+                (number)))
+            (value
+              (var
+                (local_var))))
+          (type
+            (type_keyword)
+            (addrspace
+              (number)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)
+                  (addrspace
+                    (number))))))))
+      (comment))))
+
+================================================================================
+icmp
+================================================================================
+
+define void @main() {
+  %result = icmp eq i32 4, 5          ; yields: result=false
+  %result = icmp ne float* %X, %X     ; yields: result=false
+  %result = icmp ult i16  4, 5        ; yields: result=true
+  %result = icmp sgt i16  4, 5        ; yields: result=false
+  %result = icmp ule i16 -4, 5        ; yields: result=false
+  %result = icmp sge i16  4, 5        ; yields: result=false
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_icmp
+          (icmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_icmp
+          (icmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (value
+            (var
+              (local_var)))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_icmp
+          (icmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_icmp
+          (icmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_icmp
+          (icmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_icmp
+          (icmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (comment))))
+
+================================================================================
+fcmp
+================================================================================
+
+define void @main() {
+  %result = fcmp oeq float 4.0, 5.0    ; yields: result=false
+  %result = fcmp one float 4.0, 5.0    ; yields: result=true
+  %result = fcmp olt float 4.0, 5.0    ; yields: result=true
+  %result = fcmp ueq double 1.0, 2.0   ; yields: result=false
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_fcmp
+          (fcmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (value
+            (float))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_fcmp
+          (fcmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (value
+            (float))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_fcmp
+          (fcmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (value
+            (float))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_fcmp
+          (fcmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (float)))
+          (value
+            (float))))
+      (comment))))
+
+================================================================================
+phi
+================================================================================
+
+define void @main() {
+Loop:       ; Infinite loop that counts from 0 on up...
+  %indvar = phi i32 [ 0, %LoopHeader ], [ %nextindvar, %Loop ]
+  %nextindvar = add i32 %indvar, 1
+  br label %Loop
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (label)
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_phi
+          (type
+            (type_keyword))
+          (value
+            (number))
+          (local_var)
+          (value
+            (var
+              (local_var)))
+          (local_var)))
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (value
+            (number))))
+      (instruction
+        (instruction_br
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+select
+================================================================================
+
+define void @main() {
+  %X = select i1 true, i8 17, i8 42          ; yields i8:17
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_select
+          (type_and_value
+            (type
+              (type_keyword))
+            (value))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))
+      (comment))))
+
+================================================================================
+call
+================================================================================
+
+%struct.A = type { i32, i8 }
+
+define void @main() {
+  %retval = call i32 @test(i32 %argc)
+  call i32 (i8*, ...)* @printf(i8* %msg, i32 12, i8 42)        ; yields i32
+  %X = tail call i32 @foo()                                    ; yields i32
+  %Y = tail call fastcc i32 @foo()  ; yields i32
+  call void %foo(i8 signext 97)
+  
+  %r = call %struct.A @foo()                        ; yields { i32, i8 }
+  %gr = extractvalue %struct.A %r, 0                ; yields i32
+  %gr1 = extractvalue %struct.A %r, 1               ; yields i8
+  %Z = call void @foo() noreturn                    ; indicates that %foo never returns normally
+  %ZZ = call zeroext i32 @bar()                     ; Return value is %zero extended
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (global_type
+    (local_var)
+    (type
+      (struct_type
+        (struct_body
+          (type
+            (type_keyword))
+          (type
+            (type_keyword))))))
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (local_var)))))))
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword)
+            (argument_list
+              (argument
+                (type
+                  (type_keyword)))
+              (argument)))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (local_var))))
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (number)))
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (number))))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list)))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_call
+          (calling_conv)
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list)))
+      (comment)
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var)))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (param_or_return_attrs
+                (attribute_name))
+              (value
+                (number))))))
+      (instruction
+        (local_var)
+        (instruction_call
+          (type
+            (local_var))
+          (value
+            (var
+              (global_var)))
+          (argument_list)))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_extractvalue
+          (type_and_value
+            (type
+              (local_var))
+            (value
+              (var
+                (local_var))))
+          (number)))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_extractvalue
+          (type_and_value
+            (type
+              (local_var))
+            (value
+              (var
+                (local_var))))
+          (number)))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list)
+          (attribute
+            (attribute_name))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_call
+          (param_or_return_attrs
+            (attribute_name))
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list)))
+      (comment))))
+
+================================================================================
+inline asm
+================================================================================
+
+define void @main() {
+  %X = call i32 asm "bswap $0", "=r,r"(i32 %Y)
+  call void asm sideeffect "eieio", ""()
+  call void asm alignstack "eieio", ""()
+  call void asm inteldialect "eieio", ""()
+  call void asm unwind "call func", ""()
+  call void asm sideeffect "something bad", ""(), !srcloc !42
+}
+
+!42 = !{ i32 1234567 }
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_call
+          (type
+            (type_keyword))
+          (inline_asm
+            (asm
+              (string))
+            (string))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (local_var)))))))
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (inline_asm
+            (asm
+              (string))
+            (string))
+          (argument_list)))
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (inline_asm
+            (asm
+              (string))
+            (string))
+          (argument_list)))
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (inline_asm
+            (asm
+              (string))
+            (string))
+          (argument_list)))
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (inline_asm
+            (asm
+              (string))
+            (string))
+          (argument_list)))
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (inline_asm
+            (asm
+              (string))
+            (string))
+          (argument_list))
+        (metadata_refs
+          (metadata_name)
+          (metadata
+            (specialized_md
+              (metadata_ref)))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (metadata_tuple
+        (metadata
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number))))))))
+
+================================================================================
+landingpad
+================================================================================
+
+define void @main() {
+  ;; A landing pad which can catch an integer.
+  %res = landingpad { i8*, i32 }
+           catch i8** @_ZTIi
+  ;; A landing pad that is a cleanup.
+  %res = landingpad { i8*, i32 }
+           cleanup
+  ;; A landing pad which can catch an integer and can only throw a double.
+  %res = landingpad { i8*, i32 }
+           catch i8** @_ZTIi
+           filter [1 x i8**] [i8** @_ZTId]
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_landingpad
+          (type
+            (struct_type
+              (struct_body
+                (type
+                  (type_keyword))
+                (type
+                  (type_keyword)))))
+          (landingpad_clause
+            (type_and_value
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (global_var)))))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_landingpad
+          (type
+            (struct_type
+              (struct_body
+                (type
+                  (type_keyword))
+                (type
+                  (type_keyword)))))))
+      (comment)
+      (instruction
+        (local_var)
+        (instruction_landingpad
+          (type
+            (struct_type
+              (struct_body
+                (type
+                  (type_keyword))
+                (type
+                  (type_keyword)))))
+          (landingpad_clause
+            (type_and_value
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (global_var)))))
+          (landingpad_clause
+            (type_and_value
+              (type
+                (array_type
+                  (array_vector_body
+                    (number)
+                    (type
+                      (type_keyword)))))
+              (value
+                (array_value
+                  (type_and_value
+                    (type
+                      (type_keyword))
+                    (value
+                      (var
+                        (global_var)))))))))))))
+
+================================================================================
+constant expression
+================================================================================
+
+define void @main() {
+  %tmp4 = xor i32 %tmp3, zext (i1 icmp ne (i64 ptrtoint (i32* @global5 to i64), i64 1) to i32)
+  %tmp5 = icmp eq i32 %tmp3, zext (i1 icmp ne (i64 ptrtoint (i32* @global5 to i64), i64 1) to i32)
+  store i32 ptrtoint (i32* @global to i32), i32* getelementptr inbounds (%struct.ham, %struct.ham* @global8, i64 0, i32 0), align 4
+  store i32 %tmp10, i32* getelementptr inbounds (%struct.ham, %struct.ham* @global8, i64 0, i32 0), align 4
+}
+
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (value
+            (constant_expr
+              (constant_cast
+                (cast_inst)
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (constant_expr
+                      (constant_icmp
+                        (icmp_cond)
+                        (type_and_value
+                          (type
+                            (type_keyword))
+                          (value
+                            (constant_expr
+                              (constant_cast
+                                (cast_inst)
+                                (type_and_value
+                                  (type
+                                    (type_keyword))
+                                  (value
+                                    (var
+                                      (global_var))))
+                                (type
+                                  (type_keyword))))))
+                        (type_and_value
+                          (type
+                            (type_keyword))
+                          (value
+                            (number)))))))
+                (type
+                  (type_keyword)))))))
+      (instruction
+        (local_var)
+        (instruction_icmp
+          (icmp_cond)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (value
+            (constant_expr
+              (constant_cast
+                (cast_inst)
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (constant_expr
+                      (constant_icmp
+                        (icmp_cond)
+                        (type_and_value
+                          (type
+                            (type_keyword))
+                          (value
+                            (constant_expr
+                              (constant_cast
+                                (cast_inst)
+                                (type_and_value
+                                  (type
+                                    (type_keyword))
+                                  (value
+                                    (var
+                                      (global_var))))
+                                (type
+                                  (type_keyword))))))
+                        (type_and_value
+                          (type
+                            (type_keyword))
+                          (value
+                            (number)))))))
+                (type
+                  (type_keyword)))))))
+      (instruction
+        (instruction_store
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (constant_expr
+                (constant_cast
+                  (cast_inst)
+                  (type_and_value
+                    (type
+                      (type_keyword))
+                    (value
+                      (var
+                        (global_var))))
+                  (type
+                    (type_keyword))))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (constant_expr
+                (constant_getelementptr
+                  (type_and_value
+                    (type
+                      (local_var)))
+                  (type_and_value
+                    (type
+                      (local_var))
+                    (value
+                      (var
+                        (global_var))))
+                  (type_and_value
+                    (type
+                      (type_keyword))
+                    (value
+                      (number)))
+                  (type_and_value
+                    (type
+                      (type_keyword))
+                    (value
+                      (number)))))))
+          (number)))
+      (instruction
+        (instruction_store
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (constant_expr
+                (constant_getelementptr
+                  (type_and_value
+                    (type
+                      (local_var)))
+                  (type_and_value
+                    (type
+                      (local_var))
+                    (value
+                      (var
+                        (global_var))))
+                  (type_and_value
+                    (type
+                      (type_keyword))
+                    (value
+                      (number)))
+                  (type_and_value
+                    (type
+                      (type_keyword))
+                    (value
+                      (number)))))))
+          (number))))))

--- a/test/corpus/regressions.ll
+++ b/test/corpus/regressions.ll
@@ -1,0 +1,2714 @@
+================================================================================
+cstring
+================================================================================
+@str = internal constant [18 x i8] c"Double value: %f\0A\00"
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (linkage
+      (linkage_aux))
+    (type_and_value
+      (type
+        (array_type
+          (array_vector_body
+            (number)
+            (type
+              (type_keyword)))))
+      (value
+        (cstring)))))
+
+================================================================================
+multiple argument attributes
+================================================================================
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1)
+--------------------------------------------------------------------------------
+
+(module
+  (declare
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (type_keyword))
+          (param_or_return_attrs
+            (attribute_name))
+          (param_or_return_attrs
+            (attribute_name)))
+        (argument
+          (type
+            (type_keyword))
+          (param_or_return_attrs
+            (attribute_name))
+          (param_or_return_attrs
+            (attribute_name)))
+        (argument
+          (type
+            (type_keyword)))
+        (argument
+          (type
+            (type_keyword)))))))
+
+================================================================================
+return attribute
+================================================================================
+declare zeroext i16 @foo() #0
+--------------------------------------------------------------------------------
+
+(module
+  (declare
+    (function_header
+      (param_or_return_attrs
+        (attribute_name))
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list)
+      (attribute
+        (attr_ref)))))
+
+================================================================================
+string metadata argument
+================================================================================
+define void @main() {
+  %p2 = call i1 @llvm.type.test(i8* %1, metadata !"_ZTS1D")
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (local_var))))
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref))))))))))
+
+================================================================================
+specialized metadata argument
+================================================================================
+define void @main() {
+  call void @llvm.dbg.value(metadata i32 %1, metadata !24, metadata !DIExpression()), !dbg !25
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (metadata
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (var
+                      (local_var))))))
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref))))
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref))))))
+        (metadata_refs
+          (metadata_name)
+          (metadata
+            (specialized_md
+              (metadata_ref))))))))
+
+================================================================================
+specialized metadata or
+================================================================================
+!2 = distinct !DISubprogram(name: "main", scope: !4, file: !3, line: 1, type: !12, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: !4)
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))))))
+
+================================================================================
+bfloat constant
+================================================================================
+define bfloat @check_bfloat_literal() {
+  ret bfloat 0xR3149
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number))))))))
+
+================================================================================
+global key-value pairs
+================================================================================
+@g1 = global i32 7 "key" = "value" "key2" = "value2"
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (type_and_value
+      (type
+        (type_keyword))
+      (value
+        (number)))
+    (attribute
+      (string)
+      (string))
+    (attribute
+      (string)
+      (string))))
+
+================================================================================
+packed struct
+================================================================================
+define void @qux(<{i32, i32}>* %x) nounwind {
+  store <{i32, i32}><{i32 7, i32 9}>, <{i32, i32}>* %x
+  ret void
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (packed_struct_type
+              (struct_body
+                (type
+                  (type_keyword))
+                (type
+                  (type_keyword)))))
+          (value
+            (var
+              (local_var)))))
+      (attribute
+        (attribute_name)))
+    (function_body
+      (instruction
+        (instruction_store
+          (type_and_value
+            (type
+              (packed_struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (type_keyword)))))
+            (value
+              (packed_struct_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number))))))
+          (type_and_value
+            (type
+              (packed_struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))))
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))))))))
+
+================================================================================
+specialized metadata with type and value
+================================================================================
+define void @main() {
+  call void @llvm.dbg.value(metadata !DIArgList(i32 %add, i32 %call30, i32 %call28, i32 %call26, i32 %call24, i32 %call22, i32 %call20, i32 %call18, i32 %call16, i32 %call14, i32 %call12, i32 %call10, i32 %call8, i32 %call6, i32 %call4, i32 %call2), metadata !15, metadata !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 15, DW_OP_plus, DW_OP_LLVM_arg, 14, DW_OP_plus, DW_OP_LLVM_arg, 13, DW_OP_plus, DW_OP_LLVM_arg, 12, DW_OP_plus, DW_OP_LLVM_arg, 11, DW_OP_plus, DW_OP_LLVM_arg, 10, DW_OP_plus, DW_OP_LLVM_arg, 9, DW_OP_plus, DW_OP_LLVM_arg, 8, DW_OP_plus, DW_OP_LLVM_arg, 7, DW_OP_plus, DW_OP_LLVM_arg, 6, DW_OP_plus, DW_OP_LLVM_arg, 5, DW_OP_plus, DW_OP_LLVM_arg, 4, DW_OP_plus, DW_OP_LLVM_arg, 3, DW_OP_plus, DW_OP_LLVM_arg, 2, DW_OP_plus, DW_OP_LLVM_arg, 1, DW_OP_plus, DW_OP_stack_value)), !dbg !16
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var)))
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value
+                    (var
+                      (local_var))))))
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref))))
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value))))))
+        (metadata_refs
+          (metadata_name)
+          (metadata
+            (specialized_md
+              (metadata_ref))))))))
+
+================================================================================
+global with multiple metadatas
+================================================================================
+@_ZTV1B = constant { [4 x i8*] } { [4 x i8*] [i8* null, i8* undef, i8* bitcast (i32 (%struct.B*, i32)* @_ZN1B1fEi to i8*), i8* bitcast (i32 (%struct.A*, i32)* @_ZN1A1nEi to i8*)] }, !type !0, !type !1
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (type_and_value
+      (type
+        (struct_type
+          (struct_body
+            (type
+              (array_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword))))))))
+      (value
+        (struct_value
+          (type_and_value
+            (type
+              (array_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (array_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (constant_expr
+                      (constant_cast
+                        (cast_inst)
+                        (type_and_value
+                          (type
+                            (type_keyword)
+                            (argument_list
+                              (argument
+                                (type
+                                  (local_var)))
+                              (argument
+                                (type
+                                  (type_keyword)))))
+                          (value
+                            (var
+                              (global_var))))
+                        (type
+                          (type_keyword))))))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (constant_expr
+                      (constant_cast
+                        (cast_inst)
+                        (type_and_value
+                          (type
+                            (type_keyword)
+                            (argument_list
+                              (argument
+                                (type
+                                  (local_var)))
+                              (argument
+                                (type
+                                  (type_keyword)))))
+                          (value
+                            (var
+                              (global_var))))
+                        (type
+                          (type_keyword))))))))))))
+    (metadata_refs
+      (metadata_name)
+      (metadata
+        (specialized_md
+          (metadata_ref))))
+    (metadata_refs
+      (metadata_name)
+      (metadata
+        (specialized_md
+          (metadata_ref))))))
+
+================================================================================
+parameter align metadata
+================================================================================
+define void @main() {
+  call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 8 %tmp1, i8* align 8 %memtmp2, i32 24, i1 false)
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (param_or_return_attrs
+                (number))
+              (value
+                (var
+                  (local_var))))
+            (argument
+              (type
+                (type_keyword))
+              (param_or_return_attrs
+                (number))
+              (value
+                (var
+                  (local_var))))
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (number)))
+            (argument
+              (type
+                (type_keyword))
+              (value))))))))
+
+================================================================================
+personality with constant expr
+================================================================================
+define hidden void @test_normal(i8* noalias %dst, i8* %src) personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (linkage
+        (visibility))
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (type_keyword))
+          (param_or_return_attrs
+            (attribute_name))
+          (value
+            (var
+              (local_var))))
+        (argument
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var)))))
+      (attribute
+        (type_and_value
+          (type
+            (type_keyword))
+          (value
+            (constant_expr
+              (constant_cast
+                (cast_inst)
+                (type_and_value
+                  (type
+                    (type_keyword)
+                    (argument_list
+                      (argument)))
+                  (value
+                    (var
+                      (global_var))))
+                (type
+                  (type_keyword))))))))
+    (function_body)))
+
+================================================================================
+name with dash
+================================================================================
+define void @main() {
+  %0 = phi i8* [ %add.ptr.i, %for.cond.while.cond.loopexit_crit_edge.us-lcssa ], [ %1, %while.cond ]
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_phi
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var)))
+          (local_var)
+          (value
+            (var
+              (local_var)))
+          (local_var))))))
+
+================================================================================
+opaque type
+================================================================================
+%0 = type opaque
+--------------------------------------------------------------------------------
+
+(module
+  (global_type
+    (local_var)
+    (type
+      (type_keyword))))
+
+================================================================================
+complex inline metadata
+================================================================================
+define void @main() {
+  %val = load %T, %T* %a, !alias.scope !{!10}
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_load
+          (type
+            (local_var))
+          (type_and_value
+            (type
+              (local_var))
+            (value
+              (var
+                (local_var)))))
+        (metadata_refs
+          (metadata_name)
+          (metadata
+            (metadata_tuple
+              (metadata
+                (specialized_md
+                  (metadata_ref))))))))))
+
+================================================================================
+name with backslash
+================================================================================
+define void @main() {
+  unreachable, !\34\32abc !4
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_unreachable)
+        (metadata_refs
+          (metadata_name)
+          (metadata
+            (specialized_md
+              (metadata_ref))))))))
+
+================================================================================
+quoted struct name
+================================================================================
+define void @_Z3foov(%"class.std::auto_ptr"* noalias nocapture sret(%"class.std::auto_ptr") %agg.result) ssp {
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (local_var))
+          (param_or_return_attrs
+            (attribute_name))
+          (param_or_return_attrs
+            (attribute_name))
+          (param_or_return_attrs
+            (attribute_name)
+            (type
+              (local_var)))
+          (value
+            (var
+              (local_var)))))
+      (attribute
+        (attribute_name)))
+    (function_body)))
+
+================================================================================
+externally_initialized
+================================================================================
+@GLOBAL = addrspace(1) externally_initialized global i32 0, align 4, !dbg !0
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (addrspace
+      (number))
+    (type_and_value
+      (type
+        (type_keyword))
+      (value
+        (number)))
+    (attribute
+      (alignment
+        (number)))
+    (metadata_refs
+      (metadata_name)
+      (metadata
+        (specialized_md
+          (metadata_ref))))))
+
+================================================================================
+nsw/nuw order
+================================================================================
+define void @main() {
+  %z = add nsw nuw i64 %x, %y
+	ret i64 add nsw nuw (i64 ptrtoint (i64* @addr to i64), i64 91)
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (value
+            (var
+              (local_var)))))
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (constant_expr
+                (constant_bin_op
+                  (bin_op_keyword
+                    (atomic_bin_op_keyword))
+                  (type_and_value
+                    (type
+                      (type_keyword))
+                    (value
+                      (constant_expr
+                        (constant_cast
+                          (cast_inst)
+                          (type_and_value
+                            (type
+                              (type_keyword))
+                            (value
+                              (var
+                                (global_var))))
+                          (type
+                            (type_keyword))))))
+                  (type_and_value
+                    (type
+                      (type_keyword))
+                    (value
+                      (number))))))))))))
+
+================================================================================
+readnone argument
+================================================================================
+define i32 @main(i32 %argc, i8** nocapture readnone %argv) local_unnamed_addr #0 personality i8* bitcast (i32 (...)* @__CxxFrameHandler3 to i8*) {
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var))))
+        (argument
+          (type
+            (type_keyword))
+          (param_or_return_attrs
+            (attribute_name))
+          (param_or_return_attrs
+            (attribute_name))
+          (value
+            (var
+              (local_var)))))
+      (unnamed_addr)
+      (attribute
+        (attr_ref))
+      (attribute
+        (type_and_value
+          (type
+            (type_keyword))
+          (value
+            (constant_expr
+              (constant_cast
+                (cast_inst)
+                (type_and_value
+                  (type
+                    (type_keyword)
+                    (argument_list
+                      (argument)))
+                  (value
+                    (var
+                      (global_var))))
+                (type
+                  (type_keyword))))))))
+    (function_body)))
+
+================================================================================
+select with fast-math flags
+================================================================================
+define void @main() {
+  %fabs = select nnan i1 %lezero, double %negx, double %x
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_select
+          (fast_math)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+float exponent without sign
+================================================================================
+define void @main() {
+  %t2 = fdiv arcp reassoc <2 x float> <float 15.0e0, float 7.0e0>, %t1
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword)
+          (fast_math)
+          (fast_math)
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (vector_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (float)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (float))))))
+          (value
+            (var
+              (local_var))))))))
+
+================================================================================
+label names
+================================================================================
+define void @main() {
+"2": ; string label, quoted number
+  br label %-3
+-3: ; numeric-looking, but actually string, label
+  br label %-N-
+-N-:
+  br label %$N
+$N:
+  %4 = add i32 1, 1
+  ret i32 %4
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (label)
+      (comment)
+      (instruction
+        (instruction_br
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (label)
+      (comment)
+      (instruction
+        (instruction_br
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (label)
+      (instruction
+        (instruction_br
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))))
+      (label)
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (value
+            (number))))
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+instruction attribute
+================================================================================
+define void @main() {
+  %M = call i8* @llvm.call.preallocated.arg(token %c, i32 0) preallocated(i32)
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (local_var))))
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (number))))
+          (attribute
+            (attribute_name)
+            (type
+              (type_keyword))))))))
+
+================================================================================
+quoted function name
+================================================================================
+define void @main() {
+  call void @"?terminate@@YAXXZ"() #4 [ "funclet"(token %5) ]
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list)
+          (attribute
+            (attr_ref))
+          (operand_bundles
+            (string)
+            (type_and_value
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (local_var))))))))))
+
+================================================================================
+specialized md with set
+================================================================================
+!1 = !GenericDINode(tag: 3, header: "some\00header", operands: {!0, !3, !4})
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md_value
+            (specialized_md
+              (metadata_ref)))
+          (specialized_md_value)
+          (specialized_md_value
+            (specialized_md
+              (metadata_ref)))
+          (specialized_md_value)
+          (specialized_md_value
+            (specialized_md
+              (metadata_ref))))))))
+
+================================================================================
+global with alignment
+================================================================================
+@global = external local_unnamed_addr global [4 x [4 x [2 x i16]]] align 16
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (linkage
+      (linkage_aux))
+    (unnamed_addr)
+    (type_and_value
+      (type
+        (array_type
+          (array_vector_body
+            (number)
+            (type
+              (array_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (array_type
+                      (array_vector_body
+                        (number)
+                        (type
+                          (type_keyword))))))))))))
+    (attribute
+      (alignment
+        (number)))))
+
+================================================================================
+global attributes
+================================================================================
+attributes #0 = { nofree nounwind allocsize(0) }
+--------------------------------------------------------------------------------
+
+(module
+  (unnamed_attr_grp
+    (attr_ref)
+    (attribute
+      (attribute_name))
+    (attribute
+      (attribute_name))
+    (attribute
+      (attribute_name)
+      (number))))
+
+================================================================================
+special chars
+================================================================================
+$"??_C@_0BC@CABPINND@Exception?5caught?$AA?$AA@" = comdat any
+--------------------------------------------------------------------------------
+
+(module
+  (comdat
+    (comdat_ref)))
+
+================================================================================
+summary with attribute
+================================================================================
+^2 = gv: (guid: 1, summaries: (function: (module: ^0, flags: (linkage: external, visibility: default, notEligibleToImport: 0, live: 0, dsoLocal: 0), insts: 10, calls: ((callee: ^15, hotness: hot), (callee: ^17, hotness: cold), (callee: ^16, hotness: none)), refs: (writeonly ^14, readonly ^13, ^11))))
+
+^11 = gv: (guid: 10, summaries: (variable: (module: ^0, flags: (linkage: common, visibility: default, notEligibleToImport: 0, live: 0, dsoLocal: 0), varFlags: (readonly: 0))))
+
+^2 = flags: 97
+--------------------------------------------------------------------------------
+
+(module
+  (summary_entry
+    (summary_ref)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (summary_value)
+      (summary_value)
+      (summary_value
+        (summary_value)
+        (summary_value)
+        (summary_value
+          (summary_ref))
+        (summary_value)
+        (summary_value)
+        (summary_value)
+        (summary_value
+          (summary_value)
+          (summary_value)
+          (summary_value
+            (linkage_aux))
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value
+            (number))
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value
+            (number))
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value
+            (number)))
+        (summary_value)
+        (summary_value)
+        (summary_value)
+        (summary_value
+          (number))
+        (summary_value)
+        (summary_value)
+        (summary_value)
+        (summary_value
+          (summary_value
+            (summary_value)
+            (summary_value)
+            (summary_value
+              (summary_ref))
+            (summary_value)
+            (summary_value)
+            (summary_value)
+            (summary_value
+              (attribute_name)))
+          (summary_value)
+          (summary_value
+            (summary_value)
+            (summary_value)
+            (summary_value
+              (summary_ref))
+            (summary_value)
+            (summary_value)
+            (summary_value)
+            (summary_value
+              (attribute_name)))
+          (summary_value)
+          (summary_value
+            (summary_value)
+            (summary_value)
+            (summary_value
+              (summary_ref))
+            (summary_value)
+            (summary_value)
+            (summary_value)
+            (summary_value)))
+        (summary_value)
+        (summary_value)
+        (summary_value)
+        (summary_value
+          (summary_value
+            (attribute_name))
+          (summary_value
+            (summary_ref))
+          (summary_value)
+          (summary_value
+            (attribute_name))
+          (summary_value
+            (summary_ref))
+          (summary_value)
+          (summary_value
+            (summary_ref))))))
+  (summary_entry
+    (summary_ref)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (summary_value)
+      (summary_value)
+      (summary_value
+        (summary_value)
+        (summary_value)
+        (summary_value
+          (summary_ref))
+        (summary_value)
+        (summary_value)
+        (summary_value)
+        (summary_value
+          (summary_value)
+          (summary_value)
+          (summary_value
+            (linkage_aux))
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value
+            (number))
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value
+            (number))
+          (summary_value)
+          (summary_value)
+          (summary_value)
+          (summary_value
+            (number)))
+        (summary_value)
+        (summary_value)
+        (summary_value)
+        (summary_value
+          (summary_value
+            (attribute_name))
+          (summary_value)
+          (summary_value
+            (number))))))
+  (summary_entry
+    (summary_ref)
+    (number)))
+
+================================================================================
+summary with attribute
+================================================================================
+!8 = !DITemplateValueParameter(tag: DW_TAG_GNU_template_template_param, name: "param", type: !1, value: !"template")
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))))))
+
+================================================================================
+opaque pointer
+================================================================================
+@fptr1 = external global ptr ()*
+@fptr3 = external global ptr () addrspace(1)* addrspace(2)*
+
+define ptr @g(ptr addrspace(2) %a) {
+    %b = addrspacecast ptr addrspace(2) %a to ptr addrspace(0)
+    ret ptr addrspace(0) %b
+}
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (linkage
+      (linkage_aux))
+    (type_and_value
+      (type
+        (type_keyword)
+        (argument_list))))
+  (global_global
+    (global_var)
+    (linkage
+      (linkage_aux))
+    (type_and_value
+      (type
+        (type_keyword)
+        (argument_list)
+        (addrspace
+          (number))
+        (addrspace
+          (number)))))
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (type_keyword)
+            (addrspace
+              (number)))
+          (value
+            (var
+              (local_var))))))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_cast
+          (cast_inst)
+          (type_and_value
+            (type
+              (type_keyword)
+              (addrspace
+                (number)))
+            (value
+              (var
+                (local_var))))
+          (type
+            (type_keyword)
+            (addrspace
+              (number)))))
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword)
+              (addrspace
+                (number)))
+            (value
+              (var
+                (local_var)))))))))
+
+================================================================================
+ppc_fp128 type
+================================================================================
+define void @main() {
+  %scale.0 = phi ppc_fp128 [ 0xM3FF00000000000000000000000000000, %if.else14 ], [ %scale.0, %do.body ]
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_phi
+          (type
+            (type_keyword))
+          (value
+            (number))
+          (local_var)
+          (value
+            (var
+              (local_var)))
+          (local_var))))))
+
+================================================================================
+alias with constant expression
+================================================================================
+@alias1 = alias i32, i32* getelementptr inbounds (%struct.S, %struct.S* @s, i64 0, i32 1)
+--------------------------------------------------------------------------------
+
+(module
+  (alias
+    (global_var)
+    (type
+      (type_keyword))
+    (type
+      (type_keyword))
+    (constant_expr
+      (constant_getelementptr
+        (type_and_value
+          (type
+            (local_var)))
+        (type_and_value
+          (type
+            (local_var))
+          (value
+            (var
+              (global_var))))
+        (type_and_value
+          (type
+            (type_keyword))
+          (value
+            (number)))
+        (type_and_value
+          (type
+            (type_keyword))
+          (value
+            (number)))))))
+
+================================================================================
+dso_local_equivalent call linkage
+================================================================================
+define void @caller() {
+  call void dso_local_equivalent @extern_func()
+  ret void
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (linkage
+              (dso_local))
+            (var
+              (global_var)))
+          (argument_list)))
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))))))))
+
+================================================================================
+string calling convention
+================================================================================
+declare "cc 9" void @vararg_fn_cc9(i8* %p, ...)
+--------------------------------------------------------------------------------
+
+(module
+  (declare
+    (function_header
+      (calling_conv
+        (string))
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var))))
+        (argument)))))
+
+================================================================================
+float with plus sign
+================================================================================
+define void @main() {
+  %n5n4p3 = call float @llvm.amdgcn.cubema(float -5.0, float -4.0, float +3.0)
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (float)))
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (float)))
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (float)))))))))
+
+================================================================================
+atomic ordering and alignment
+================================================================================
+define void @main() {
+  atomicrmw add i8* %p, i8 0 seq_cst, align 1
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_atomicrmw
+          (atomic_bin_op_keyword)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (atomic_ordering)
+          (alignment
+            (number)))))))
+
+================================================================================
+function metadata
+================================================================================
+define void @foo(i1 %f0, i1 %f1, i1 %f2) !prof !{!"function_entry_count", i64 0} {
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var))))
+        (argument
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var))))
+        (argument
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var))))))
+    (metadata_attachment
+      (metadata_name)
+      (metadata
+        (metadata_tuple
+          (metadata
+            (specialized_md
+              (metadata_ref)))
+          (metadata
+            (type_and_value
+              (type
+                (type_keyword))
+              (value
+                (number)))))))
+    (function_body)))
+
+================================================================================
+constant expression fneg
+================================================================================
+define void @main() {
+  %fma = call float @llvm.fma.f32(float fneg (float bitcast (i32 ptrtoint (i32* @external to i32) to float)), float %y.fneg, float %z)
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (constant_expr
+                  (constant_fneg
+                    (type_and_value
+                      (type
+                        (type_keyword))
+                      (value
+                        (constant_expr
+                          (constant_cast
+                            (cast_inst)
+                            (type_and_value
+                              (type
+                                (type_keyword))
+                              (value
+                                (constant_expr
+                                  (constant_cast
+                                    (cast_inst)
+                                    (type_and_value
+                                      (type
+                                        (type_keyword))
+                                      (value
+                                        (var
+                                          (global_var))))
+                                    (type
+                                      (type_keyword))))))
+                            (type
+                              (type_keyword))))))))))
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (local_var))))
+            (argument
+              (type
+                (type_keyword))
+              (value
+                (var
+                  (local_var))))))))))
+
+================================================================================
+unsigned hex constant
+================================================================================
+define void @main() {
+  %1 = catchpad within %cs1 [i8* null, i32 u0x40, i8* null]
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_catchpad
+          (local_var)
+          (type_and_value
+            (type
+              (type_keyword))
+            (value))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value)))))))
+
+================================================================================
+specialized metadata angle brackets
+================================================================================
+!0 = distinct !DICompileUnit(language: <LANG1>, file: !1, producer: "clang")
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md_value))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))))))
+
+================================================================================
+no_cfi function attribute
+================================================================================
+@a = global [6 x void ()*] [void ()* no_cfi @f1, void ()* @f1, void ()* @f2, void ()* no_cfi @f2, void ()* @f3, void ()* no_cfi @f3]
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (type_and_value
+      (type
+        (array_type
+          (array_vector_body
+            (number)
+            (type
+              (type_keyword)
+              (argument_list)))))
+      (value
+        (array_value
+          (type_and_value
+            (type
+              (type_keyword)
+              (argument_list))
+            (value
+              (linkage)
+              (var
+                (global_var))))
+          (type_and_value
+            (type
+              (type_keyword)
+              (argument_list))
+            (value
+              (var
+                (global_var))))
+          (type_and_value
+            (type
+              (type_keyword)
+              (argument_list))
+            (value
+              (var
+                (global_var))))
+          (type_and_value
+            (type
+              (type_keyword)
+              (argument_list))
+            (value
+              (linkage)
+              (var
+                (global_var))))
+          (type_and_value
+            (type
+              (type_keyword)
+              (argument_list))
+            (value
+              (var
+                (global_var))))
+          (type_and_value
+            (type
+              (type_keyword)
+              (argument_list))
+            (value
+              (linkage)
+              (var
+                (global_var)))))))))
+
+================================================================================
+specialized metadata with function type
+================================================================================
+!16 = !DITemplateValueParameter(name: "b", type: !17, value: i8 ()* @_Z1av)
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (type_keyword))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (var
+            (global_var)))))))
+
+================================================================================
+specialized metadata with constant expression
+================================================================================
+!11 = !DITemplateValueParameter(type: !12, value: %Tricky.1* bitcast (i8* @templateValueParam to %Tricky.1*))
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (var
+            (local_var)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md_value
+            (type_keyword))
+          (specialized_md_value)
+          (specialized_md_value
+            (var
+              (global_var)))
+          (specialized_md_value)
+          (specialized_md_value
+            (var
+              (local_var)))
+          (specialized_md_value))))))
+
+================================================================================
+int hex literal
+================================================================================
+define void @main() {
+  %1 = alloca [u0x200000000 x i8]
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (local_var)
+        (instruction_alloca
+          (type
+            (array_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword))))))))))
+
+================================================================================
+ifunc with unnamed_addr
+================================================================================
+@i2 = internal local_unnamed_addr ifunc void(), void()* ()* @f2
+--------------------------------------------------------------------------------
+
+(module
+  (ifunc
+    (global_var)
+    (linkage
+      (linkage_aux))
+    (unnamed_addr)
+    (type
+      (type_keyword)
+      (argument_list))
+    (type
+      (type_keyword)
+      (argument_list)
+      (argument_list))
+    (global_var)))
+
+================================================================================
+global partition
+================================================================================
+@g1 = global i32 0, partition "part4"
+@a1 = alias i32, i32* @g1, partition "part5"
+@i1 = ifunc void(), void()* ()* @f1, partition "part6"
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (type_and_value
+      (type
+        (type_keyword))
+      (value
+        (number)))
+    (attribute
+      (string)))
+  (alias
+    (global_var)
+    (type
+      (type_keyword))
+    (type
+      (type_keyword))
+    (global_var)
+    (attribute
+      (string)))
+  (ifunc
+    (global_var)
+    (type
+      (type_keyword)
+      (argument_list))
+    (type
+      (type_keyword)
+      (argument_list)
+      (argument_list))
+    (global_var)
+    (attribute
+      (string))))
+
+================================================================================
+specialized metadata string with backslash before quote end
+================================================================================
+!9 = !DIFile(filename: "./test2.cpp", directory: "C:\")
+!12 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)))))
+
+================================================================================
+signed hex constant
+================================================================================
+@1 = global i63  s0x012312   ; hexadecimal signed integer constants
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (type_and_value
+      (type
+        (type_keyword))
+      (value
+        (number))))
+  (comment))
+
+================================================================================
+signed hex constant
+================================================================================
+define void @main() {
+  load <16 x i32>, <16 x i32>* %0load <16 x i32>, <16 x i32>* %1load <16 x i32>, <16 x i32>* %2load <16 x i32>, <16 x i32>* %3load <16 x i32>, <16 x i32>* %4load <16 x i32>, <16 x i32>* %5load <16 x i32>, <16 x i32>* %6call <16 x i32> @llvm.hexagon.V6.vd0()
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_load
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))))
+      (instruction
+        (instruction_load
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))))
+      (instruction
+        (instruction_load
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))))
+      (instruction
+        (instruction_load
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))))
+      (instruction
+        (instruction_load
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))))
+      (instruction
+        (instruction_load
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))))
+      (instruction
+        (instruction_load
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))
+          (type_and_value
+            (type
+              (vector_type
+                (array_vector_body
+                  (number)
+                  (type
+                    (type_keyword)))))
+            (value
+              (var
+                (local_var))))))
+      (instruction
+        (instruction_call
+          (type
+            (vector_type
+              (array_vector_body
+                (number)
+                (type
+                  (type_keyword)))))
+          (value
+            (var
+              (global_var)))
+          (argument_list))))))
+
+================================================================================
+metadata name with escape
+================================================================================
+!llvm.named.register.r1\3A0 = !{!32}
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (metadata_tuple
+        (metadata
+          (specialized_md
+            (metadata_ref)))))))
+
+================================================================================
+global function
+================================================================================
+@obj = dso_local unnamed_addr constant { { i32, i32 } } {
+  { i32, i32 } {
+    i32 0,
+    i32 trunc (i64 sub (i64 ptrtoint (void ()* dso_local_equivalent @hidden_func to i64), i64 ptrtoint (i32* getelementptr inbounds ({ { i32, i32 } }, { { i32, i32 } }* @obj, i32 0, i32 0, i32 1) to i64)) to i32)
+  } }, align 4
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (linkage
+      (dso_local))
+    (unnamed_addr)
+    (type_and_value
+      (type
+        (struct_type
+          (struct_body
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (type_keyword))))))))
+      (value
+        (struct_value
+          (type_and_value
+            (type
+              (struct_type
+                (struct_body
+                  (type
+                    (type_keyword))
+                  (type
+                    (type_keyword)))))
+            (value
+              (struct_value
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (number)))
+                (type_and_value
+                  (type
+                    (type_keyword))
+                  (value
+                    (constant_expr
+                      (constant_cast
+                        (cast_inst)
+                        (type_and_value
+                          (type
+                            (type_keyword))
+                          (value
+                            (constant_expr
+                              (constant_bin_op
+                                (bin_op_keyword
+                                  (atomic_bin_op_keyword))
+                                (type_and_value
+                                  (type
+                                    (type_keyword))
+                                  (value
+                                    (constant_expr
+                                      (constant_cast
+                                        (cast_inst)
+                                        (type_and_value
+                                          (type
+                                            (type_keyword)
+                                            (argument_list))
+                                          (value
+                                            (linkage
+                                              (dso_local))
+                                            (var
+                                              (global_var))))
+                                        (type
+                                          (type_keyword))))))
+                                (type_and_value
+                                  (type
+                                    (type_keyword))
+                                  (value
+                                    (constant_expr
+                                      (constant_cast
+                                        (cast_inst)
+                                        (type_and_value
+                                          (type
+                                            (type_keyword))
+                                          (value
+                                            (constant_expr
+                                              (constant_getelementptr
+                                                (type_and_value
+                                                  (type
+                                                    (struct_type
+                                                      (struct_body
+                                                        (type
+                                                          (struct_type
+                                                            (struct_body
+                                                              (type
+                                                                (type_keyword))
+                                                              (type
+                                                                (type_keyword)))))))))
+                                                (type_and_value
+                                                  (type
+                                                    (struct_type
+                                                      (struct_body
+                                                        (type
+                                                          (struct_type
+                                                            (struct_body
+                                                              (type
+                                                                (type_keyword))
+                                                              (type
+                                                                (type_keyword))))))))
+                                                  (value
+                                                    (var
+                                                      (global_var))))
+                                                (type_and_value
+                                                  (type
+                                                    (type_keyword))
+                                                  (value
+                                                    (number)))
+                                                (type_and_value
+                                                  (type
+                                                    (type_keyword))
+                                                  (value
+                                                    (number)))
+                                                (type_and_value
+                                                  (type
+                                                    (type_keyword))
+                                                  (value
+                                                    (number)))))))
+                                        (type
+                                          (type_keyword))))))))))
+                        (type
+                          (type_keyword))))))))))))
+    (attribute
+      (alignment
+        (number)))))
+
+================================================================================
+constant expression function pointer
+================================================================================
+@obj = constant i64 ptrtoint (void ()* dso_local_equivalent @hidden_func to i64)
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (type_and_value
+      (type
+        (type_keyword))
+      (value
+        (constant_expr
+          (constant_cast
+            (cast_inst)
+            (type_and_value
+              (type
+                (type_keyword)
+                (argument_list))
+              (value
+                (linkage
+                  (dso_local))
+                (var
+                  (global_var))))
+            (type
+              (type_keyword))))))))
+
+================================================================================
+inline metadata
+================================================================================
+define void @main() {
+  call void @llvm.dbg.value(metadata !DIArgList(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0)), metadata !14, metadata !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_stack_value)), !dbg !15
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref)
+                  (specialized_md_value
+                    (type_keyword))
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (specialized_md_value
+                      (specialized_md_value
+                        (number))
+                      (specialized_md_value)
+                      (specialized_md_value
+                        (type_keyword)))
+                    (specialized_md_value)
+                    (specialized_md_value
+                      (specialized_md_value
+                        (number))
+                      (specialized_md_value)
+                      (specialized_md_value
+                        (type_keyword)))
+                    (specialized_md_value)
+                    (specialized_md_value
+                      (var
+                        (global_var)))
+                    (specialized_md_value)
+                    (specialized_md_value
+                      (type_keyword))
+                    (specialized_md_value
+                      (number))
+                    (specialized_md_value)
+                    (specialized_md_value
+                      (type_keyword))
+                    (specialized_md_value
+                      (number))))))
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref))))
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref)
+                  (specialized_md_value)
+                  (specialized_md_value)
+                  (specialized_md_value
+                    (number))
+                  (specialized_md_value)
+                  (specialized_md_value))))))
+        (metadata_refs
+          (metadata_name)
+          (metadata
+            (specialized_md
+              (metadata_ref))))))))

--- a/test/corpus/structure.ll
+++ b/test/corpus/structure.ll
@@ -1,0 +1,2453 @@
+================================================================================
+Triple
+================================================================================
+target triple = "amdgcn-amd-amdhsa"
+--------------------------------------------------------------------------------
+
+(module
+  (target_definition
+    (target_triple
+      (string))))
+
+================================================================================
+Data Layout
+================================================================================
+target datalayout = ""
+--------------------------------------------------------------------------------
+
+(module
+  (target_definition
+    (data_layout
+      (string))))
+
+================================================================================
+Function Declaration
+================================================================================
+declare float @llvm.sqrt(float) nounwind readnone
+--------------------------------------------------------------------------------
+
+(module
+  (declare
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (type_keyword))))
+      (attribute
+        (attribute_name))
+      (attribute
+        (attribute_name)))))
+
+================================================================================
+Function Definition
+================================================================================
+define void @test() nounwind {
+  ret void
+}
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list)
+      (attribute
+        (attribute_name)))
+    (function_body
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))))))))
+
+================================================================================
+Global Assembly
+================================================================================
+module asm "inline asm code goes here"
+module asm "more can go here"
+--------------------------------------------------------------------------------
+
+(module
+  (module_asm
+    (asm
+      (string)))
+  (module_asm
+    (asm
+      (string))))
+
+================================================================================
+Global Variable
+================================================================================
+@G = addrspace(5) constant float 1.0, section "foo", align 4
+
+@G = external global i32
+
+@"complex@Name" = thread_local(initialexec) global i32 0, align 4
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (addrspace
+      (number))
+    (type_and_value
+      (type
+        (type_keyword))
+      (value
+        (float)))
+    (attribute
+      (string))
+    (attribute
+      (alignment
+        (number))))
+  (global_global
+    (global_var)
+    (linkage
+      (linkage_aux))
+    (type_and_value
+      (type
+        (type_keyword))))
+  (global_global
+    (global_var)
+    (thread_local)
+    (type_and_value
+      (type
+        (type_keyword))
+      (value
+        (number)))
+    (attribute
+      (alignment
+        (number)))))
+
+================================================================================
+Comdat
+================================================================================
+$foo = comdat largest
+@foo = global i32 2, comdat($foo)
+
+define void @bar() comdat($foo) {
+  ret void
+}
+--------------------------------------------------------------------------------
+
+(module
+  (comdat
+    (comdat_ref))
+  (global_global
+    (global_var)
+    (type_and_value
+      (type
+        (type_keyword))
+      (value
+        (number)))
+    (attribute
+      (comdat_ref)))
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list)
+      (attribute
+        (comdat_ref)))
+    (function_body
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword))))))))
+
+================================================================================
+Metadata
+================================================================================
+!0 = distinct !{!"test\00", i32 10}
+
+!foo = !{!4, !3}
+
+define void @main() {
+  call void @llvm.dbg.value(metadata !24, metadata !25, metadata !26)
+  %indvar.next = add i64 %indvar, 1, !dbg !21
+}
+declare !dbg !22 void @f1()
+define void @f2() !dbg !22 {
+  ret void
+}
+
+@g1 = global i32 0, !dbg !22
+@g2 = external global i32, !dbg !22
+
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (metadata_tuple
+        (metadata
+          (specialized_md
+            (metadata_ref)))
+        (metadata
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (number)))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (metadata_tuple
+        (metadata
+          (specialized_md
+            (metadata_ref)))
+        (metadata
+          (specialized_md
+            (metadata_ref))))))
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (function_body
+      (instruction
+        (instruction_call
+          (type
+            (type_keyword))
+          (value
+            (var
+              (global_var)))
+          (argument_list
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref))))
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref))))
+            (argument
+              (metadata
+                (specialized_md
+                  (metadata_ref)))))))
+      (instruction
+        (local_var)
+        (instruction_bin_op
+          (bin_op_keyword
+            (atomic_bin_op_keyword))
+          (type_and_value
+            (type
+              (type_keyword))
+            (value
+              (var
+                (local_var))))
+          (value
+            (number)))
+        (metadata_refs
+          (metadata_name)
+          (metadata
+            (specialized_md
+              (metadata_ref)))))))
+  (declare
+    (metadata_attachment
+      (metadata_name)
+      (metadata
+        (specialized_md
+          (metadata_ref))))
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list)))
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list))
+    (metadata_attachment
+      (metadata_name)
+      (metadata
+        (specialized_md
+          (metadata_ref))))
+    (function_body
+      (instruction
+        (instruction_ret
+          (type_and_value
+            (type
+              (type_keyword)))))))
+  (global_global
+    (global_var)
+    (type_and_value
+      (type
+        (type_keyword))
+      (value
+        (number)))
+    (metadata_refs
+      (metadata_name)
+      (metadata
+        (specialized_md
+          (metadata_ref)))))
+  (global_global
+    (global_var)
+    (linkage
+      (linkage_aux))
+    (type_and_value
+      (type
+        (type_keyword)))
+    (metadata_refs
+      (metadata_name)
+      (metadata
+        (specialized_md
+          (metadata_ref))))))
+
+================================================================================
+Debug Data
+================================================================================
+!0 = !DILocation(line: 2900, column: 42, scope: !1, inlinedAt: !2)
+
+!0 = !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang",
+                    isOptimized: true, flags: "-O2", runtimeVersion: 2,
+                    splitDebugFilename: "abc.debug", emissionKind: FullDebug,
+                    enums: !2, retainedTypes: !3, globals: !4, imports: !5,
+                    macros: !6, dwoId: 0x0abcd)
+
+!0 = !DIFile(filename: "path/to/file", directory: "/path/to/dir",
+             checksumkind: CSK_MD5,
+             checksum: "000102030405060708090a0b0c0d0e0f")
+
+!0 = !DIBasicType(name: "unsigned char", size: 8, align: 8,
+                  encoding: DW_ATE_unsigned_char)
+!1 = !DIBasicType(tag: DW_TAG_unspecified_type, name: "decltype(nullptr)")
+
+!0 = !BasicType(name: "int", size: 32, align: 32, DW_ATE_signed)
+!1 = !BasicType(name: "char", size: 8, align: 8, DW_ATE_signed_char)
+!2 = !DISubroutineType(types: !{null, !0, !1}) ; void (int, char)
+
+!0 = !DIBasicType(name: "unsigned char", size: 8, align: 8,
+                  encoding: DW_ATE_unsigned_char)
+!1 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !0, size: 32,
+                    align: 32)
+
+!0 = !DIEnumerator(name: "SixKind", value: 7)
+!1 = !DIEnumerator(name: "SevenKind", value: 7)
+!2 = !DIEnumerator(name: "NegEightKind", value: -8)
+!3 = !DICompositeType(tag: DW_TAG_enumeration_type, name: "Enum", file: !12,
+                      line: 2, size: 32, align: 32, identifier: "_M4Enum",
+                      elements: !{!0, !1, !2})
+
+!0 = !DISubrange(count: 5, lowerBound: 0) ; array counting from 0
+!1 = !DISubrange(count: 5, lowerBound: 1) ; array counting from 1
+!2 = !DISubrange(count: -1) ; empty array.
+
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (metadata_tuple
+            (metadata)
+            (metadata
+              (specialized_md
+                (metadata_ref)))
+            (metadata
+              (specialized_md
+                (metadata_ref))))))))
+  (comment)
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (metadata_tuple
+            (metadata
+              (specialized_md
+                (metadata_ref)))
+            (metadata
+              (specialized_md
+                (metadata_ref)))
+            (metadata
+              (specialized_md
+                (metadata_ref))))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (comment)
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (comment)
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (comment))
+
+================================================================================
+Debug Data 2
+================================================================================
+; Scopes used in rest of example
+!6 = !DIFile(filename: "vla.c", directory: "/path/to/file")
+!7 = distinct !DICompileUnit(language: DW_LANG_C99, file: !6)
+!8 = distinct !DISubprogram(name: "foo", scope: !7, file: !6, line: 5)
+
+; Use of local variable as count value
+!9 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!10 = !DILocalVariable(name: "count", scope: !8, file: !6, line: 42, type: !9)
+!11 = !DISubrange(count: !10, lowerBound: 0)
+
+; Use of global variable as count value
+!12 = !DIGlobalVariable(name: "count", scope: !8, file: !6, line: 22, type: !9)
+!13 = !DISubrange(count: !12, lowerBound: 0)
+
+!0 = !DIEnumerator(name: "SixKind", value: 7)
+!1 = !DIEnumerator(name: "SevenKind", value: 7)
+!2 = !DIEnumerator(name: "NegEightKind", value: -8)
+
+!0 = !DITemplateTypeParameter(name: "Ty", type: !1)
+
+!0 = !DITemplateValueParameter(name: "Ty", type: !1, value: i32 7)
+
+!0 = !DINamespace(name: "myawesomeproject", scope: !1, file: !2, line: 7)
+
+--------------------------------------------------------------------------------
+
+(module
+  (comment)
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (comment)
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (comment)
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (type_keyword))
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))))))
+
+================================================================================
+Debug Data 3
+================================================================================
+@foo = global i32, !dbg !0
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = !DIGlobalVariable(name: "foo", linkageName: "foo", scope: !2,
+                       file: !3, line: 7, type: !4, isLocal: true,
+                       isDefinition: false, declaration: !5)
+
+@lower = global i32, !dbg !0
+@upper = global i32, !dbg !1
+!0 = !DIGlobalVariableExpression(
+         var: !2,
+         expr: !DIExpression(DW_OP_LLVM_fragment, 0, 32)
+         )
+!1 = !DIGlobalVariableExpression(
+         var: !2,
+         expr: !DIExpression(DW_OP_LLVM_fragment, 32, 32)
+         )
+!2 = !DIGlobalVariable(name: "split64", linkageName: "split64", scope: !3,
+                       file: !4, line: 8, type: !5, declaration: !6)
+
+!0 = distinct !DISubprogram(name: "foo", linkageName: "_Zfoov", scope: !1,
+                            file: !2, line: 7, type: !3, isLocal: true,
+                            isDefinition: true, scopeLine: 8,
+                            containingType: !4,
+                            virtuality: DW_VIRTUALITY_pure_virtual,
+                            virtualIndex: 10, flags: DIFlagPrototyped,
+                            isOptimized: true, unit: !5, templateParams: !6,
+                            declaration: !7, retainedNodes: !8,
+                            thrownTypes: !9)
+
+!0 = distinct !DILexicalBlock(scope: !1, file: !2, line: 7, column: 35)
+
+--------------------------------------------------------------------------------
+
+(module
+  (global_global
+    (global_var)
+    (type_and_value
+      (type
+        (type_keyword)))
+    (metadata_refs
+      (metadata_name)
+      (metadata
+        (specialized_md
+          (metadata_ref)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_global
+    (global_var)
+    (type_and_value
+      (type
+        (type_keyword)))
+    (metadata_refs
+      (metadata_name)
+      (metadata
+        (specialized_md
+          (metadata_ref)))))
+  (global_global
+    (global_var)
+    (type_and_value
+      (type
+        (type_keyword)))
+    (metadata_refs
+      (metadata_name)
+      (metadata
+        (specialized_md
+          (metadata_ref)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)
+            (specialized_md_value)
+            (specialized_md_value)
+            (specialized_md_value
+              (number))
+            (specialized_md_value)
+            (specialized_md_value
+              (number)))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)
+            (specialized_md_value)
+            (specialized_md_value)
+            (specialized_md_value
+              (number))
+            (specialized_md_value)
+            (specialized_md_value
+              (number)))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))))))
+
+================================================================================
+Debug Data 4
+================================================================================
+!0 = !DILexicalBlock(scope: !3, file: !4, line: 7, column: 35)
+!1 = !DILexicalBlockFile(scope: !0, file: !4, discriminator: 0)
+!2 = !DILexicalBlockFile(scope: !0, file: !4, discriminator: 1)
+
+!0 = !DILocation(line: 2900, column: 42, scope: !1, inlinedAt: !2)
+
+!0 = !DILocalVariable(name: "this", arg: 1, scope: !3, file: !2, line: 7,
+                      type: !3, flags: DIFlagArtificial)
+!1 = !DILocalVariable(name: "x", arg: 2, scope: !4, file: !2, line: 7,
+                      type: !3)
+!2 = !DILocalVariable(name: "y", scope: !5, file: !2, line: 7, type: !3)
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))))))
+
+================================================================================
+Debug Data 5
+================================================================================
+!17 = !DILocalVariable(name: "ptr1", scope: !12, file: !3, line: 5,
+                       type: !18)
+!18 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!19 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!20 = !DIExpression(DW_OP_LLVM_implicit_pointer)
+
+!0 = !DIExpression(DW_OP_deref)
+!1 = !DIExpression(DW_OP_plus_uconst, 3)
+!1 = !DIExpression(DW_OP_constu, 3, DW_OP_plus)
+!2 = !DIExpression(DW_OP_bit_piece, 3, 7)
+!3 = !DIExpression(DW_OP_deref, DW_OP_constu, 3, DW_OP_plus, DW_OP_LLVM_fragment, 3, 7)
+!4 = !DIExpression(DW_OP_constu, 2, DW_OP_swap, DW_OP_xderef)
+!5 = !DIExpression(DW_OP_constu, 42, DW_OP_stack_value)
+
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)))))
+
+================================================================================
+Debug Data 5
+================================================================================
+!3 = !DIObjCProperty(name: "foo", file: !1, line: 7, setter: "setFoo",
+                     getter: "getFoo", attributes: 7, type: !2)
+
+!2 = !DIImportedEntity(tag: DW_TAG_imported_module, name: "foo", scope: !0,
+                       entity: !1, line: 7, elements: !3)
+!3 = !{!4}
+!4 = !DIImportedEntity(tag: DW_TAG_imported_declaration, name: "bar", scope: !0,
+                       entity: !5, line: 7)
+
+!2 = !DIMacro(macinfo: DW_MACINFO_define, line: 7, name: "foo(x)",
+              value: "((x) + 1)")
+!3 = !DIMacro(macinfo: DW_MACINFO_undef, line: 30, name: "foo")
+
+!2 = !DIMacroFile(macinfo: DW_MACINFO_start_file, line: 7, file: !2,
+                  nodes: !3)
+
+!2 = !DILabel(scope: !0, name: "foo", file: !1, line: 7)
+--------------------------------------------------------------------------------
+
+(module
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (metadata_tuple
+        (metadata
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string)))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref))))))
+  (global_metadata
+    (metadata_ref)
+    (metadata
+      (specialized_md
+        (metadata_ref)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (string))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (specialized_md
+            (metadata_ref)))
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value)
+        (specialized_md_value
+          (number))))))
+
+================================================================================
+Summary
+================================================================================
+^0 = module: (path: "/path/to/file.o", hash: (2468601609, 1329373163, 1565878005, 638838075, 3148790418))
+^1 = gv: (name: "f") ; guid = 14740650423002898831
+^2 = variable: (module: ^0, flags: (linkage: external, notEligibleToImport: 0, live: 0, dsoLocal: 0))
+^3 = alias: (module: ^0, flags: (linkage: external, notEligibleToImport: 0, live: 0, dsoLocal: 0), aliasee: ^2)
+^4 = funcFlags: (readNone: 0, readOnly: 0, noRecurse: 0, returnDoesNotAlias: 0, noInline: 0, alwaysInline: 0, noUnwind: 1, mayThrow: 0, hasUnknownCall: 0)
+^5 = vFuncId: (TypeIdRef, offset: 16)
+^6 = typeid: (name: "_ZTS1A", summary: (typeTestRes: (kind: allOnes, sizeM1BitWidth: 7)))
+--------------------------------------------------------------------------------
+
+(module
+  (summary_entry
+    (summary_ref)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (string))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (summary_value
+        (number))
+      (summary_value)
+      (summary_value
+        (number))
+      (summary_value)
+      (summary_value
+        (number))
+      (summary_value)
+      (summary_value
+        (number))
+      (summary_value)
+      (summary_value
+        (number))))
+  (summary_entry
+    (summary_ref)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (string)))
+  (comment)
+  (summary_entry
+    (summary_ref)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (summary_ref))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (summary_value)
+      (summary_value)
+      (summary_value
+        (linkage_aux))
+      (summary_value)
+      (summary_value)
+      (summary_value)
+      (summary_value
+        (number))
+      (summary_value)
+      (summary_value)
+      (summary_value)
+      (summary_value
+        (number))
+      (summary_value)
+      (summary_value)
+      (summary_value)
+      (summary_value
+        (number))))
+  (summary_entry
+    (summary_ref)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (summary_ref))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (summary_value)
+      (summary_value)
+      (summary_value
+        (linkage_aux))
+      (summary_value)
+      (summary_value)
+      (summary_value)
+      (summary_value
+        (number))
+      (summary_value)
+      (summary_value)
+      (summary_value)
+      (summary_value
+        (number))
+      (summary_value)
+      (summary_value)
+      (summary_value)
+      (summary_value
+        (number)))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (summary_ref)))
+  (summary_entry
+    (summary_ref)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number)))
+  (summary_entry
+    (summary_ref)
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (number)))
+  (summary_entry
+    (summary_ref)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (string))
+    (summary_value)
+    (summary_value)
+    (summary_value)
+    (summary_value
+      (summary_value)
+      (summary_value)
+      (summary_value
+        (summary_value)
+        (summary_value)
+        (summary_value)
+        (summary_value)
+        (summary_value)
+        (summary_value)
+        (summary_value
+          (number))))))
+
+================================================================================
+Attribute Group
+================================================================================
+; Target-independent attributes:
+attributes #0 = { alwaysinline alignstack=4 }
+
+; Target-dependent attributes:
+attributes #1 = { "no-sse" }
+
+; Function @f has attributes: alwaysinline, alignstack=4, and "no-sse".
+define void @f() #0 #1 { }
+--------------------------------------------------------------------------------
+
+(module
+  (comment)
+  (unnamed_attr_grp
+    (attr_ref)
+    (attribute
+      (attribute_name))
+    (attribute
+      (attribute_name)
+      (number)))
+  (comment)
+  (unnamed_attr_grp
+    (attr_ref)
+    (attribute
+      (string)))
+  (comment)
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list)
+      (attribute
+        (attr_ref))
+      (attribute
+        (attr_ref)))
+    (function_body)))
+
+================================================================================
+Uselist order
+================================================================================
+define void @foo(i32 %arg1, i32 %arg2) {
+entry:
+  ; ... instructions ...
+bb:
+  ; ... instructions ...
+
+  ; At function scope.
+  uselistorder i32 %arg1, { 1, 0, 2 }
+  uselistorder label %bb, { 1, 0 }
+}
+
+; At global scope.
+uselistorder i32* @global, { 1, 2, 0 }
+uselistorder i32 7, { 1, 0 }
+uselistorder i32 (i32) @bar, { 1, 0 }
+uselistorder_bb @foo, %bb, { 5, 1, 3, 2, 0, 4 }
+--------------------------------------------------------------------------------
+
+(module
+  (define
+    (function_header
+      (type
+        (type_keyword))
+      (global_var)
+      (argument_list
+        (argument
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var))))
+        (argument
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var))))))
+    (function_body
+      (label)
+      (comment)
+      (label)
+      (comment)
+      (comment)
+      (use_list_order
+        (type_and_value
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var))))
+        (number)
+        (number)
+        (number))
+      (use_list_order
+        (type_and_value
+          (type
+            (type_keyword))
+          (value
+            (var
+              (local_var))))
+        (number)
+        (number))))
+  (comment)
+  (use_list_order
+    (type_and_value
+      (type
+        (type_keyword))
+      (value
+        (var
+          (global_var))))
+    (number)
+    (number)
+    (number))
+  (use_list_order
+    (type_and_value
+      (type
+        (type_keyword))
+      (value
+        (number)))
+    (number)
+    (number))
+  (use_list_order
+    (type_and_value
+      (type
+        (type_keyword)
+        (argument_list
+          (argument
+            (type
+              (type_keyword)))))
+      (value
+        (var
+          (global_var))))
+    (number)
+    (number))
+  (use_list_order_bb
+    (global_var)
+    (local_var)
+    (number)
+    (number)
+    (number)
+    (number)
+    (number)
+    (number)))
+
+================================================================================
+alias
+================================================================================
+@nestedarray.1 = alias i8*, getelementptr inbounds ([2 x [4 x i8*]], [2 x [4 x i8*]]* @nestedarray, inrange i32 0, i32 0, i32 4)
+@bar2 = alias i8* (), i8* ()* @bar
+--------------------------------------------------------------------------------
+
+(module
+  (alias
+    (global_var)
+    (type
+      (type_keyword))
+    (constant_expr
+      (constant_getelementptr
+        (type_and_value
+          (type
+            (array_type
+              (array_vector_body
+                (number)
+                (type
+                  (array_type
+                    (array_vector_body
+                      (number)
+                      (type
+                        (type_keyword)))))))))
+        (type_and_value
+          (type
+            (array_type
+              (array_vector_body
+                (number)
+                (type
+                  (array_type
+                    (array_vector_body
+                      (number)
+                      (type
+                        (type_keyword))))))))
+          (value
+            (var
+              (global_var))))
+        (type_and_value
+          (type
+            (type_keyword))
+          (value
+            (number)))
+        (type_and_value
+          (type
+            (type_keyword))
+          (value
+            (number)))
+        (type_and_value
+          (type
+            (type_keyword))
+          (value
+            (number))))))
+  (alias
+    (global_var)
+    (type
+      (type_keyword)
+      (argument_list))
+    (type
+      (type_keyword)
+      (argument_list))
+    (global_var)))
+
+================================================================================
+ifunc
+================================================================================
+@bar = ifunc void (), void ()* ()* @bar_resolve
+--------------------------------------------------------------------------------
+
+(module
+  (ifunc
+    (global_var)
+    (type
+      (type_keyword)
+      (argument_list))
+    (type
+      (type_keyword)
+      (argument_list)
+      (argument_list))
+    (global_var)))


### PR DESCRIPTION
Add more semantic meaning of functions and instructions.
This allows e.g. selecting functions or arguments and context-sensitive
highlighting (e.g. for a `%struct` in it's definition or usage as a
type).

The implementation is based on the parser implementation in llvm and the
llvm language reference.
The instruction tests are taken from the llvm language reference.

I ran the parser on the llvm test suite (filtering out the tests that
contain invalid IR) and it doesn't emit ERROR or MISSING on them.