### PR TITLE
Add "ll" to supported file types

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     {
       "scope": "source.llvm",
       "file-types": [
-        "llvm"
+        "llvm",
+        "ll"
       ]
     }
   ],


### PR DESCRIPTION
When trying to use this parser with the `tree-sitter highlight` cli command, the file type detection currently only works for files with a `.llvm` file extension, but not for files ending with `.ll`. This PR fixes that.