### PR TITLE
Upgrade to Tree-sitter 0.25, rename `define` symbol, and unify bindings to 1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+*.a
+*.o
+*.pc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter-llvm
-        VERSION "1.0.0"
+        VERSION "1.1.0"
         DESCRIPTION "Tree sitter parser for LLVM"
         HOMEPAGE_URL "git+https://github.com/benwilliamgraham/tree-sitter-llvm.git"
         LANGUAGES C)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.20.0"
+tree-sitter = "~0.25.6"
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "tree-sitter-llvm"
 description = "LLVM grammar for the tree-sitter parsing library"
-version = "0.1.0"
+version = "1.1.0"
 keywords = ["incremental", "parsing", "LLVM"]
 categories = ["parsing", "text-editors"]
+authors = ["Benjamin Graham <benwilliamgraham@gmail.com>", "Flakebi", "leifhelm", "luc-tielen", "RubixDev", "Acture"]
 repository = "https://github.com/tree-sitter/tree-sitter-LLVM"
 edition = "2024"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tree-sitter-llvm"
 description = "LLVM grammar for the tree-sitter parsing library"
-version = "0.0.1"
+version = "0.1.0"
 keywords = ["incremental", "parsing", "LLVM"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-LLVM"
-edition = "2018"
+edition = "2024"
 license = "MIT"
 
 build = "bindings/rust/build.rs"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.0.1
+VERSION := 1.1.0
 
 LANGUAGE_NAME := tree-sitter-llvm
 

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,7 +6,7 @@
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_llvm::language()).expect("Error loading LLVM grammar");
+//! parser.set_language(&tree_sitter_llvm::language()).expect("Error loading LLVM grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!
@@ -46,7 +46,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
+            .set_language(&super::language())
             .expect("Error loading LLVM language");
     }
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -17,7 +17,7 @@
 
 use tree_sitter::Language;
 
-extern "C" {
+unsafe extern "C" {
     fn tree_sitter_llvm() -> Language;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-llvm",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Tree sitter parser for LLVM",
   "main": "bindings/node",
   "types": "bindings/node",
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/benwilliamgraham/tree-sitter-llvm.git"
   },
-  "author": "Benjamin Graham",
+  "authors": "Benjamin Graham, Flakebi, leifhelm, luc-tielen, RubixDev, Acture",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/benwilliamgraham/tree-sitter-llvm/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-llvm"
 description = "Llvm grammar for tree-sitter"
-version = "0.0.1"
+version = "1.1.0"
 keywords = ["incremental", "parsing", "tree-sitter", "llvm"]
 classifiers = [
   "Intended Audience :: Developers",
@@ -22,7 +22,7 @@ readme = "README.md"
 Homepage = "https://github.com/tree-sitter/tree-sitter-llvm"
 
 [project.optional-dependencies]
-core = ["tree-sitter~=0.21"]
+core = ["tree-sitter~=0.25.6"]
 
 [tool.cibuildwheel]
 build = "cp38-*"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -21,7 +21,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "define"
+            "name": "fn_define"
           },
           {
             "type": "SYMBOL",
@@ -433,7 +433,7 @@
         }
       ]
     },
-    "define": {
+    "fn_define": {
       "type": "SEQ",
       "members": [
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -769,7 +769,27 @@
     }
   },
   {
-    "type": "define",
+    "type": "dll_storage_class",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "dso_local",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "fast_math",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "fcmp_cond",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "fn_define",
     "named": true,
     "fields": {
       "body": {
@@ -797,26 +817,6 @@
         }
       ]
     }
-  },
-  {
-    "type": "dll_storage_class",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "dso_local",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "fast_math",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "fcmp_cond",
-    "named": true,
-    "fields": {}
   },
   {
     "type": "function_body",
@@ -2625,7 +2625,7 @@
           "named": true
         },
         {
-          "type": "define",
+          "type": "fn_define",
           "named": true
         },
         {

--- a/test/corpus/instructions.ll
+++ b/test/corpus/instructions.ll
@@ -11,7 +11,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -73,7 +73,7 @@ IfUnequal:
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -139,10 +139,10 @@ define void @main() {
   ; Emulate a conditional br instruction
   %Val = zext i1 %value to i32
   switch i32 %Val, label %truedest [ i32 0, label %falsedest ]
-  
+
   ; Emulate an unconditional br instruction
   switch i32 0, label %dest [ ]
-  
+
   ; Implement a jump table:
   switch i32 %val, label %otherwise [ i32 0, label %onzero
                                      i32 1, label %onone
@@ -152,7 +152,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -271,7 +271,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -319,7 +319,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -390,7 +390,7 @@ define void @main() {
   ; "asm goto" without output constraints.
   callbr void asm "", "r,X"(i32 %x, i8 *blockaddress(@foo, %indirect))
               to label %fallthrough [label %indirect]
-  
+
   ; "asm goto" with output constraints.
   %result = callbr i32 asm "", "=r,r,X"(i32 %x, i8 *blockaddress(@foo, %indirect))
                to label %fallthrough [label %indirect]
@@ -399,7 +399,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -489,7 +489,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -524,7 +524,7 @@ dispatch2:
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -576,7 +576,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -605,7 +605,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -636,7 +636,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -665,7 +665,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -698,7 +698,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -732,7 +732,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -780,7 +780,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -827,7 +827,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -859,7 +859,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -891,7 +891,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -923,7 +923,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -955,7 +955,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -987,7 +987,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1019,7 +1019,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1055,7 +1055,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1164,7 +1164,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1284,7 +1284,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1401,7 +1401,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1462,7 +1462,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1524,7 +1524,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1597,7 +1597,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1635,7 +1635,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1685,7 +1685,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1932,7 +1932,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1969,7 +1969,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2056,7 +2056,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2115,7 +2115,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2168,7 +2168,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2221,7 +2221,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2268,7 +2268,7 @@ done:
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2412,7 +2412,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2483,7 +2483,7 @@ entry:
             (type_keyword))
           (type
             (local_var))))))
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2570,7 +2570,7 @@ define i32* @foo(%struct.ST* %s) {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2739,27 +2739,27 @@ define void @main() {
   %eptr = getelementptr [12 x i8], [12 x i8]* %aptr, i64 0, i32 1
   ; yields i32*:iptr
   %iptr = getelementptr [10 x i32], [10 x i32]* @arr, i16 0, i16 0
-  
+
   ; All arguments are vectors:
   ;   A[i] = ptrs[i] + offsets[i]*sizeof(i8)
   %A = getelementptr i8, <4 x i8*> %ptrs, <4 x i64> %offsets
-  
+
   ; Add the same scalar offset to each pointer of a vector:
   ;   A[i] = ptrs[i] + offset*sizeof(i8)
   %A = getelementptr i8, <4 x i8*> %ptrs, i64 %offset
-  
+
   ; Add distinct offsets to the same pointer:
   ;   A[i] = ptr + offsets[i]*sizeof(i8)
   %A = getelementptr i8, i8* %ptr, <4 x i64> %offsets
-  
+
   ; In all cases described above the type of the result is <4 x i8*>
-  
+
   getelementptr  %struct.ST, <4 x %struct.ST*> %s, <4 x i64> %ind1,
     <4 x i32> <i32 2, i32 2, i32 2, i32 2>,
     <4 x i32> <i32 1, i32 1, i32 1, i32 1>,
     <4 x i32> %ind4,
     <4 x i64> <i64 13, i64 13, i64 13, i64 13>
-  
+
   getelementptr  %struct.ST, <4 x %struct.ST*> %s, <4 x i64> %ind1,
     i32 2, i32 1, <4 x i32> %ind4, i64 13
 }
@@ -2767,7 +2767,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3188,7 +3188,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3282,7 +3282,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3369,7 +3369,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3443,7 +3443,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3516,7 +3516,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3560,7 +3560,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3606,7 +3606,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3663,7 +3663,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3719,7 +3719,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3763,7 +3763,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3808,7 +3808,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3877,7 +3877,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -3956,7 +3956,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -4040,7 +4040,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -4119,7 +4119,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -4215,7 +4215,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -4285,7 +4285,7 @@ Loop:       ; Infinite loop that counts from 0 on up...
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -4339,7 +4339,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -4377,7 +4377,7 @@ define void @main() {
   %X = tail call i32 @foo()                                    ; yields i32
   %Y = tail call fastcc i32 @foo()  ; yields i32
   call void %foo(i8 signext 97)
-  
+
   %r = call %struct.A @foo()                        ; yields { i32, i8 }
   %gr = extractvalue %struct.A %r, 0                ; yields i32
   %gr1 = extractvalue %struct.A %r, 1               ; yields i8
@@ -4397,7 +4397,7 @@ define void @main() {
             (type_keyword))
           (type
             (type_keyword))))))
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -4560,7 +4560,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -4664,7 +4664,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -4749,7 +4749,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))

--- a/test/corpus/regressions.ll
+++ b/test/corpus/regressions.ll
@@ -80,7 +80,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -116,7 +116,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -219,7 +219,7 @@ define bfloat @check_bfloat_literal() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -265,7 +265,7 @@ define void @qux(<{i32, i32}>* %x) nounwind {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -333,7 +333,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -674,7 +674,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -723,7 +723,7 @@ define hidden void @test_normal(i8* noalias %dst, i8* %src) personality i8* bitc
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (linkage
         (visibility))
@@ -774,7 +774,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -816,7 +816,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -851,7 +851,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -874,7 +874,7 @@ define void @_Z3foov(%"class.std::auto_ptr"* noalias nocapture sret(%"class.std:
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -933,7 +933,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -993,7 +993,7 @@ define i32 @main(i32 %argc, i8** nocapture readnone %argv) local_unnamed_addr #0
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1047,7 +1047,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1086,7 +1086,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1139,7 +1139,7 @@ $N:
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1206,7 +1206,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1247,7 +1247,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1602,7 +1602,7 @@ define ptr @g(ptr addrspace(2) %a) {
           (number))
         (addrspace
           (number)))))
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1653,7 +1653,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1718,7 +1718,7 @@ define void @caller() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1773,7 +1773,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1814,7 +1814,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1847,7 +1847,7 @@ define void @foo(i1 %f0, i1 %f1, i1 %f2) !prof !{!"function_entry_count", i64 0}
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1895,7 +1895,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -1963,7 +1963,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2161,7 +2161,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2305,7 +2305,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2641,7 +2641,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2722,7 +2722,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2751,7 +2751,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2816,7 +2816,7 @@ define void @main() {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))

--- a/test/corpus/structure.ll
+++ b/test/corpus/structure.ll
@@ -50,7 +50,7 @@ define void @test() nounwind {
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -147,7 +147,7 @@ define void @bar() comdat($foo) {
         (number)))
     (attribute
       (comdat_ref)))
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -207,7 +207,7 @@ define void @f2() !dbg !22 {
         (metadata
           (specialized_md
             (metadata_ref))))))
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -263,7 +263,7 @@ define void @f2() !dbg !22 {
         (type_keyword))
       (global_var)
       (argument_list)))
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2251,7 +2251,7 @@ define void @f() #0 #1 { }
     (attribute
       (string)))
   (comment)
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))
@@ -2285,7 +2285,7 @@ uselistorder_bb @foo, %bb, { 5, 1, 3, 2, 0, 4 }
 --------------------------------------------------------------------------------
 
 (module
-  (define
+  (fn_define
     (function_header
       (type
         (type_keyword))

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -13,7 +13,7 @@
     }
   ],
   "metadata": {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "license": "MIT",
     "description": "Tree sitter parser for LLVM",
     "authors": [


### PR DESCRIPTION
### Summary

This PR introduces coordinated changes to bring the grammar and all bindings (Rust, Python, Node.js) up to date with recent Tree-sitter developments and prepare for a consistent 1.1.0 release.

### What's Changed

- ⬆️ **Upgrade Tree-sitter from 0.20.x to 0.25.x**
  - Updates Rust binding to use the new `&Language` API
  - Ensures compatibility with recent Tree-sitter runtime

- 🧠 **Rename `define` symbol → `fn_define`**
  - Disambiguates top-level function declarations
  - Requires updates to test corpora and downstream queries

- 📦 **Unify version numbers across all bindings**
  - `Cargo.toml`, `package.json`, `pyproject.toml`, and `CMakeLists.txt` now use version `1.1.0`
  - Enables coordinated release across crates.io / npm / PyPI

- 🧹 Adds common native artifacts (`*.a`, `*.o`, `*.pc`) to `.gitignore`
- Recent versions of Rust require unsafe blocks around extern "C" declarations to match their calling context. 

### Breaking Changes

- The symbol rename breaks compatibility with tools or queries relying on `define`
- Rust binding users must upgrade Tree-sitter and adapt to `&Language`
- 